### PR TITLE
Fix incorrect VSCE PAT secret name

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -142,9 +142,7 @@ jobs:
         path: ghul-${{ needs.version.outputs.package }}.vsix
 
     - name: VSCE publish
-      run: npx vsce publish -p ${{ secrets.VSCE_TOKEN }}
-      env:
-        VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+      run: npx vsce publish -p ${{ secrets.VSCE_PAT }}
 
   create_release:
     needs: [version, unit_tests]


### PR DESCRIPTION
- Fix wrong VSCE PAT secret name in create_release pipeline job