### PR TITLE
Fix missing pipeline job dependency

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -145,7 +145,7 @@ jobs:
       run: npx vsce publish -p ${{ secrets.VSCE_PAT }}
 
   create_release:
-    needs: [version, unit_tests]
+    needs: [version, unit_tests, publish_release_package]
     name: Create release
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
- `create_release` job needs to depend on `publish_release_package`