### PR TITLE
Fix spurious errors on file delete, file rename, and file creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,18 +11,20 @@
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+	// "settings": {},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint"
-	],
+	// "extensions": [
+	// 	"dbaeumer.vscode-eslint"
+	// ],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
+
+	"postCreateCommand": "npm install -g vsce && npm install -g typescript",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghul",
-  "version": "0.6.1",
+  "version": "0.6.7-alpha.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghul",
-      "version": "0.6.1",
+      "version": "0.6.7-alpha.15",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/vscode": "^1.63.1",

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "ghul",
   "displayName": "ghūl",
   "description": "ghūl language support",
-  "version": "0.6.1",
+  "version": "0.6.7-alpha.15",
   "publisher": "degory",
   "license": "GPL-3.0",
   "repository": {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -33,9 +33,7 @@ export function activate(context: ExtensionContext) {
 				workspace.createFileSystemWatcher('**/*.ghulproj'),
 				workspace.createFileSystemWatcher('**/Directory.Build.props'),
 				workspace.createFileSystemWatcher('**/dotnet-tools.json'),
-
-				// FIXME not getting useful created and deleted events from these:
-				// workspace.createFileSystemWatcher('**/*.ghul', false, true, false),
+				workspace.createFileSystemWatcher('**/*.ghul', false, true, false),
 			]
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ghul",
-	"version": "0.6.1",
+	"version": "0.6.7-alpha.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ghul",
-			"version": "0.6.1",
+			"version": "0.6.7-alpha.15",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ghul",
 	"displayName": "ghūl",
 	"description": "ghūl language support",
-	"version": "0.6.1",
+	"version": "0.6.7-alpha.15",
 	"publisher": "degory",
 	"license": "GPL-3.0",
 	"repository": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghul-vsce",
-  "version": "0.6.1",
+  "version": "0.6.7-alpha.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ghul-vsce",
-      "version": "0.6.1",
+      "version": "0.6.7-alpha.15",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/file-url": "^2.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "ghul-vsce",
   "displayName": "ghūl language server",
   "description": "ghul language server",
-  "version": "0.6.1",
+  "version": "0.6.7-alpha.15",
   "author": "degory",
   "license": "GPL-3.0",
   "engines": {

--- a/server/src/connection-event-handler.ts
+++ b/server/src/connection-event-handler.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 
 import {
     DidChangeConfigurationParams,
@@ -127,10 +126,13 @@ export class ConnectionEventHandler {
 
         this.config = getGhulConfig(this.workspace_root);
 
+        // FIXME is there a better way to do this?
+        const workspace_root_munged = this.workspace_root.replace(/\\/g, '/');
+        
         this.document_change_tracker = 
             new DocumentChangeTracker(
                 this.edit_queue,
-                this.config.source.map(glob => path.join(this.workspace_root, glob))
+                this.config.source.map(glob => `${workspace_root_munged}/${glob}`)
             );
 
         this.config_event_emitter.configAvailable(this.workspace_root, this.config);

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+version=$1
+
+# Update package.json in the project root
+npm --prefix ./ version --no-git-tag $version
+
+# Update package.json in the client subdirectory
+npm --prefix ./client version --no-git-tag $version
+
+# Update package.json in the server subdirectory
+npm --prefix ./server version --no-git-tag $version
+
+# Run the genversion npm script to update the version number exposed to the project source code
+npm run genversion


### PR DESCRIPTION
Bugs fixed:
- Source file renames could cause spurious errors to be reported (closes #8)
- Source file deletions could cause spurious errors to be reported (closes #7)
- Contents of files added to the project from outside of VSCode were ignored until the file was viewed in VSCode

Technical:
- Implemented watching for source file creation and deletion
- Source file contents are read from disk upon creation and removed from memory upon deletion