### PR TITLE
Fix spurious analyser errors on fresh checkout

### DIFF
--- a/server/src/connection-event-handler.ts
+++ b/server/src/connection-event-handler.ts
@@ -112,10 +112,15 @@ export class ConnectionEventHandler {
     }
 
     initialize() {
-        this.config = getGhulConfig(this.workspace_root);
-
+        // generateAssembliesJson writes .assemblies.json; getGhulConfig
+        // reads it to build the -a flags for .analysis.rsp. Must run in
+        // this order — on a fresh checkout the file does not yet exist,
+        // so a reversed order leaves the analyser with no -a flags and
+        // it falls back to a five-assembly default.
         restoreDotNetTools(this.workspace_root)
         generateAssembliesJson(this.workspace_root);
+
+        this.config = getGhulConfig(this.workspace_root);
 
         // FIXME is there a better way to do this?
         const workspace_root_munged = this.workspace_root.replace(/\\/g, '/');

--- a/server/tests/connection-event-handler.test.ts
+++ b/server/tests/connection-event-handler.test.ts
@@ -164,6 +164,44 @@ describe('ConnectionEventHandler', () => {
         } as GhulConfig);
     });
 
+    it('should generate .assemblies.json before reading it via getGhulConfig', () => {
+        // getGhulConfig builds the -a argument list from .assemblies.json,
+        // which is written by generateAssembliesJson. If the read runs first
+        // on a fresh checkout where the file does not yet exist, .analysis.rsp
+        // ends up empty and the analyser falls back to a tiny default
+        // assembly list — producing spurious "not defined" / "not found"
+        // diagnostics for any reference outside that list.
+        const restoreDotNetToolsSpy = jest.spyOn(restoreDotNetTools, 'restoreDotNetTools').mockImplementation();
+        const generateAssembliesJsonSpy = jest.spyOn(generateAssembliesJson, 'generateAssembliesJson').mockImplementation();
+        const getGhulConfigSpy = jest.spyOn(GetGhulConfig, 'getGhulConfig').mockReturnValue({
+            compiler: ['ghul'],
+            source: ["test.ghul"],
+            arguments: [],
+            want_plaintext_hover: false,
+        } as GhulConfig);
+
+        jest.spyOn(DocumentChangeTrackerModule, 'DocumentChangeTracker').mockImplementation(() => ({
+            onDidOpenTextDocument: jest.fn(),
+            onDidOpen: jest.fn(),
+            onDidCloseTextDocument: jest.fn(),
+            onDidClose: jest.fn(),
+            onDidChangeWatchedFiles: jest.fn(),
+        } as any as DocumentChangeTracker));
+
+        jest.spyOn(configEventEmitter, 'configAvailable').mockImplementation();
+
+        connectionEventHandler.workspace_root = '/path/to/workspace';
+
+        connectionEventHandler.initialize();
+
+        const generateOrder = generateAssembliesJsonSpy.mock.invocationCallOrder[0];
+        const restoreOrder = restoreDotNetToolsSpy.mock.invocationCallOrder[0];
+        const configOrder = getGhulConfigSpy.mock.invocationCallOrder[0];
+
+        expect(restoreOrder).toBeLessThan(generateOrder);
+        expect(generateOrder).toBeLessThan(configOrder);
+    });
+
     it('should handle onInitialize event', () => {
         // Arrange
         const initializeSpy = jest.spyOn(connectionEventHandler, 'initialize').mockImplementation();


### PR DESCRIPTION
Bugs fixed:
- On a workspace opened for the first time, the analyser reported many spurious "X is not defined" / "member Y not found" diagnostics for .NET reference symbols that compile cleanly in build mode (e.g. `System.Diagnostics.Process`, `System.Text.RegularExpressions.Regex`, `System.IO.Abstractions`, `System.Reflection.MetadataLoadContext`). Cause: `initialize()` called `getGhulConfig` — which reads `.assemblies.json` to build the `-a` flags — before `generateAssembliesJson`, the MSBuild target that produces it. On a fresh checkout the file did not yet exist, so `.analysis.rsp` ended up as a 2-byte `-A` and the analyser fell back to its five-assembly default list. A no-op edit could not clear the errors because the broken rsp file controlled assembly loading for the analyser's whole lifetime. Reorder so `restoreDotNetTools` and `generateAssembliesJson` run before `getGhulConfig`. The ordering had been correct before #63 swapped it.

Technical:
- New regression test in `connection-event-handler.test.ts` pins `restoreDotNetTools` → `generateAssembliesJson` → `getGhulConfig` as the required invocation order via `mock.invocationCallOrder`.