### PR TITLE
Back off instead of looping when the ghūl project can't be loaded

### DIFF
--- a/server/src/connection-event-handler.ts
+++ b/server/src/connection-event-handler.ts
@@ -117,10 +117,29 @@ export class ConnectionEventHandler {
         // this order — on a fresh checkout the file does not yet exist,
         // so a reversed order leaves the analyser with no -a flags and
         // it falls back to a five-assembly default.
-        restoreDotNetTools(this.workspace_root)
-        generateAssembliesJson(this.workspace_root);
+        let problems: string[] = [];
+
+        let tools_problem = restoreDotNetTools(this.workspace_root);
+        if (tools_problem) {
+            problems.push(tools_problem);
+        }
+
+        let assemblies_problem = generateAssembliesJson(this.workspace_root);
+        if (assemblies_problem) {
+            problems.push(assemblies_problem);
+        }
 
         this.config = getGhulConfig(this.workspace_root);
+        problems.push(...(this.config.problems ?? []));
+
+        // A degraded-but-runnable load: warn so the user knows analysis may be
+        // incomplete. A load with no usable compiler is fatal and reported as
+        // an error by the server manager when it declines to spawn.
+        if (problems.length && this.config.compiler?.length) {
+            this.connection.window?.showWarningMessage(
+                "ghūl language extension: " + problems.join("; ")
+            );
+        }
 
         // FIXME is there a better way to do this?
         const workspace_root_munged = this.workspace_root.replace(/\\/g, '/');

--- a/server/src/extension-state.ts
+++ b/server/src/extension-state.ts
@@ -109,7 +109,8 @@ export class ExtensionState {
             this.config_event_emitter,
             this.server_event_emitter,
             this.edit_queue,
-            this.response_parser	
+            this.response_parser,
+            this.connection
         );
         
         this.response_handler.setServerManager(this.server_manager);

--- a/server/src/generate-assemblies-json.ts
+++ b/server/src/generate-assemblies-json.ts
@@ -2,14 +2,28 @@ import { execSync } from 'child_process';
 import { readdirSync } from 'fs';
 import { log } from './log';
 
-export function generateAssembliesJson(workspace: string) {
+// Returns a human-readable problem description if generation failed, or null
+// on success / nothing-to-do. A broken .ghulproj makes `dotnet build` exit
+// non-zero, and execSync turns that into a thrown error — which, uncaught,
+// crashes initialize() and leaves the extension restarting in a loop.
+export function generateAssembliesJson(workspace: string): string | null {
     let files = readdirSync(workspace);
 
-    if (files.find(file => file.endsWith(".ghulproj"))) {
-        log("generating .assemblies.json...");
+    if (!files.find(file => file.endsWith(".ghulproj"))) {
+        log("no .ghulproj found: cannot generate .assemblies.json");
+        return null;
+    }
+
+    log("generating .assemblies.json...");
+
+    try {
         log(execSync("dotnet build -verbosity:minimal -t:GenerateAssembliesJson").toString());
         log("finished generating .assemblies.json");
-    } else {
-        log("no .ghulproj found: cannot generate .assemblies.json");
+        return null;
+    } catch (e) {
+        let problem = `could not generate .assemblies.json — the ghūl project may be missing or invalid: ` +
+            `${e instanceof Error ? e.message : String(e)}`;
+        log(problem);
+        return problem;
     }
 }

--- a/server/src/ghul-config.ts
+++ b/server/src/ghul-config.ts
@@ -13,6 +13,12 @@ export interface GhulConfig {
 	source: string[],
 	arguments: string[],
 	want_plaintext_hover: boolean,
+	// Human-readable descriptions of anything that went wrong while loading
+	// the configuration — an unreadable project file, malformed JSON, no
+	// compiler found. Empty when the workspace loaded cleanly. Consumers use
+	// this to surface a diagnostic and to decide whether to back off rather
+	// than spawn-and-fail in a loop.
+	problems: string[],
 }
 
 interface GhulConfigJson {
@@ -46,7 +52,7 @@ interface GhulProjectXml {
 			}
 		],
 		ItemGroup: [
-			{ 
+			{
 				GhulSources: {
 					"$": {
 						"Include": string
@@ -57,14 +63,24 @@ interface GhulProjectXml {
 	}
 }
 
+function describeError(e: unknown): string {
+	return e instanceof Error ? e.message : String(e);
+}
+
 export function getGhulConfig(workspace: string): GhulConfig {
-	let config: GhulConfigJson;
+	let problems: string[] = [];
+
+	let config: GhulConfigJson = {};
 
 	if (existsSync(workspace + "/ghul.json")) {
-		let buffer = '' + readFileSync(workspace + "/ghul.json", "utf-8").replace(/^\uFEFF/, '');
-		config = <GhulConfigJson>JSON.parse(buffer);
-	} else {
-		config = {}
+		try {
+			let buffer = '' + readFileSync(workspace + "/ghul.json", "utf-8").replace(/^\uFEFF/, '');
+			config = <GhulConfigJson>JSON.parse(buffer);
+		} catch (e) {
+			let problem = `could not load ghul.json: ${describeError(e)}`;
+			log(problem);
+			problems.push(problem);
+		}
 	}
 
 	let compiler: string[];
@@ -94,78 +110,93 @@ export function getGhulConfig(workspace: string): GhulConfig {
 	if (projects.length == 1) {
 		let ghulProjFileName = projects[0];
 
-		let buffer = '' + readFileSync(ghulProjFileName, "utf-8").replace(/^\uFEFF/, '');
+		try {
+			let buffer = '' + readFileSync(ghulProjFileName, "utf-8").replace(/^\uFEFF/, '');
 
-		parseXmlString(buffer, (error, projectXml: GhulProjectXml) => {
-			if (!error && projectXml.Project) {
-				if (!config.update_compiler_tool && projectXml.Project.PropertyGroup) {
-					let updateCompilerTool =
-						projectXml.Project.PropertyGroup
-						.filter(pg => pg.UpdateCompilerTool)
-						.map(pg => pg.UpdateCompilerTool)[0]
+			parseXmlString(buffer, (error, projectXml: GhulProjectXml) => {
+				if (!error && projectXml && projectXml.Project) {
+					if (!config.update_compiler_tool && projectXml.Project.PropertyGroup) {
+						let updateCompilerTool =
+							projectXml.Project.PropertyGroup
+							.filter(pg => pg.UpdateCompilerTool)
+							.map(pg => pg.UpdateCompilerTool)[0]
 
-					if (updateCompilerTool) {
-						log('will update any locally installed compiler tool to latest version');
-						config.update_compiler_tool = true;
+						if (updateCompilerTool) {
+							log('will update any locally installed compiler tool to latest version');
+							config.update_compiler_tool = true;
+						}
 					}
-				}
 
-				if (!compiler && projectXml.Project.PropertyGroup) {
-					let compilerCommandLine =
-						projectXml.Project.PropertyGroup
-							.filter(pg => pg.GhulCompiler)
-							.map(pg => pg.GhulCompiler)
-								[0]?.[0];
+					if (!compiler && projectXml.Project.PropertyGroup) {
+						let compilerCommandLine =
+							projectXml.Project.PropertyGroup
+								.filter(pg => pg.GhulCompiler)
+								.map(pg => pg.GhulCompiler)
+									[0]?.[0];
 
-					if ((compilerCommandLine ?? "") != "") {
-						compiler = parse(compilerCommandLine).map(e => e.toString());
+						if ((compilerCommandLine ?? "") != "") {
+							compiler = parse(compilerCommandLine).map(e => e.toString());
 
-						log(`will use compiler '${quote([...compiler, ...args])}' specified in ${ghulProjFileName}`);						
+							log(`will use compiler '${quote([...compiler, ...args])}' specified in ${ghulProjFileName}`);
+						}
 					}
+
+					if (!config.source?.length && projectXml.Project.ItemGroup) {
+						config.source = [];
+
+						projectXml.Project.ItemGroup
+							.filter(ig => ig.GhulSources)
+							.map(ig => ig.GhulSources)
+
+							.forEach(item => {
+								item
+									.filter(pattern => pattern["$"]?.Include)
+									.map(pattern => pattern["$"]?.Include)
+
+									.forEach(pattern => {
+										config.source.push(pattern)
+									})
+								}
+							);
+					} else if(config.source) {
+						config.source = config.source.map(directory => directory + "/**/*.ghul");
+					}
+				} else {
+					let problem = `could not parse ghūl project file ${ghulProjFileName}` +
+						(error ? `: ${describeError(error)}` : "");
+					log(problem);
+					problems.push(problem);
 				}
-
-				if (!config.source?.length && projectXml.Project.ItemGroup) {
-					config.source = [];
-
-					projectXml.Project.ItemGroup
-						.filter(ig => ig.GhulSources)
-						.map(ig => ig.GhulSources)
-
-						.forEach(item => {
-							item
-								.filter(pattern => pattern["$"]?.Include)
-								.map(pattern => pattern["$"]?.Include)
-						
-								.forEach(pattern => {
-									config.source.push(pattern)
-								})
-							}
-						);
-				} else if(config.source) {
-					config.source = config.source.map(directory => directory + "/**/*.ghul");
-				}
-			} else {
-				log("failed to parse ghul project file " + ghulProjFileName);
-			}
-		})
+			})
+		} catch (e) {
+			let problem = `could not read ghūl project file ${ghulProjFileName}: ${describeError(e)}`;
+			log(problem);
+			problems.push(problem);
+		}
 	} else if(projects.length > 0) {
 		log("ignoring multiple .ghulproj files:" + projects.join(','));
 	}
 
 	if (!compiler) {
 		if (existsSync(workspace + "/.config/dotnet-tools.json")) {
-			let buffer = ('' + readFileSync(workspace + "/.config/dotnet-tools.json", "utf-8")).replace(/^\uFEFF/, '');
+			try {
+				let buffer = ('' + readFileSync(workspace + "/.config/dotnet-tools.json", "utf-8")).replace(/^\uFEFF/, '');
 
-			let toolConfig = JSON.parse(buffer) as DotNetToolsJson;
+				let toolConfig = JSON.parse(buffer) as DotNetToolsJson;
 
-			let { tools } = toolConfig;
+				let { tools } = toolConfig;
 
-			let ghulCompilerTool = tools["ghul.compiler"]; 
+				let ghulCompilerTool = tools["ghul.compiler"];
 
-			if (ghulCompilerTool && ghulCompilerTool.commands.length == 1) {
-				compiler = ["dotnet", "tool", "run", ghulCompilerTool.commands[0]]
+				if (ghulCompilerTool && ghulCompilerTool.commands.length == 1) {
+					compiler = ["dotnet", "tool", "run", ghulCompilerTool.commands[0]]
 
-				log(`will use compiler '${quote([...compiler, ...args])}' version ${ghulCompilerTool.version} from local tool manifest`);
+					log(`will use compiler '${quote([...compiler, ...args])}' version ${ghulCompilerTool.version} from local tool manifest`);
+				}
+			} catch (e) {
+				let problem = `could not load .config/dotnet-tools.json: ${describeError(e)}`;
+				log(problem);
+				problems.push(problem);
 			}
 		}
 
@@ -191,7 +222,9 @@ export function getGhulConfig(workspace: string): GhulConfig {
 	}
 
 	if (!compiler) {
-		log("no usable ghūl compiler found")
+		let problem = "no usable ghūl compiler found: install the ghul.compiler tool or set 'compiler' in ghul.json";
+		log(problem);
+		problems.push(problem);
 	}
 
 	if (config.update_compiler_tool) {
@@ -203,18 +236,24 @@ export function getGhulConfig(workspace: string): GhulConfig {
 			log('compiler tool update successful');
 		} else {
 			log(result.stderr);
-			log('compiler tool update failed');			
+			log('compiler tool update failed');
 		}
 	}
 
-	if (existsSync(workspace + "/.assemblies.json")) {		
-		let buffer = ('' + readFileSync(workspace + "/.assemblies.json", "utf-8")).replace(/^\uFEFF/, '');
+	if (existsSync(workspace + "/.assemblies.json")) {
+		try {
+			let buffer = ('' + readFileSync(workspace + "/.assemblies.json", "utf-8")).replace(/^\uFEFF/, '');
 
-		let { assemblies } = JSON.parse(buffer) as { assemblies: string[] };
-		
-		for (let assembly of assemblies) {
-			args.push("-a");
-			args.push(assembly);
+			let { assemblies } = JSON.parse(buffer) as { assemblies: string[] };
+
+			for (let assembly of assemblies) {
+				args.push("-a");
+				args.push(assembly);
+			}
+		} catch (e) {
+			let problem = `could not load .assemblies.json: ${describeError(e)}`;
+			log(problem);
+			problems.push(problem);
 		}
 	}
 
@@ -227,6 +266,7 @@ export function getGhulConfig(workspace: string): GhulConfig {
 		compiler,
 		source,
 		arguments: args,
-		want_plaintext_hover: config.want_plaintext_hover ?? false
+		want_plaintext_hover: config.want_plaintext_hover ?? false,
+		problems
 	};
 }

--- a/server/src/restore-dotnet-tools.ts
+++ b/server/src/restore-dotnet-tools.ts
@@ -2,12 +2,24 @@ import { execSync } from 'child_process';
 import { log } from './log';
 import { existsSync } from 'fs';
 
-export function restoreDotNetTools(workspace: string) {
-    if (existsSync(workspace + '/.config/dotnet-tools.json')) {
-        log("restoring .NET tools...");
-        log(execSync("dotnet tool restore").toString());
-        log("finished restoring .NET tools")
-    } else {
+// Returns a human-readable problem description if the restore failed, or null
+// on success / nothing-to-do. execSync throws on a non-zero exit; callers run
+// this during initialize(), so a thrown error there crashes the whole load.
+export function restoreDotNetTools(workspace: string): string | null {
+    if (!existsSync(workspace + '/.config/dotnet-tools.json')) {
         log("no .config/dotnet-tools.json found: won't attempt to restore .NET tools");
+        return null;
+    }
+
+    log("restoring .NET tools...");
+
+    try {
+        log(execSync("dotnet tool restore").toString());
+        log("finished restoring .NET tools");
+        return null;
+    } catch (e) {
+        let problem = `could not restore .NET tools: ${e instanceof Error ? e.message : String(e)}`;
+        log(problem);
+        return problem;
     }
 }

--- a/server/src/server-manager.ts
+++ b/server/src/server-manager.ts
@@ -6,6 +6,8 @@ import {
 	ChildProcess
 } from 'child_process';
 
+import { Connection } from 'vscode-languageserver';
+
 import { log } from './log';
 import { resolveAllPendingPromises } from './extension-state';
 
@@ -23,14 +25,25 @@ export enum ServerState {
 	StartingUp,
 	Listening,
 	Aborted,
-	Blocked
+	Blocked,
+	// The compiler could not be started — either it was never resolved, or it
+	// kept failing and we have given up retrying. We stay here, doing nothing,
+	// until a fresh configuration arrives (the user edits a project file).
+	Failed
 }
+
+// How many consecutive failed starts to tolerate before giving up. A healthy
+// run (the compiler reaching the Listening state) resets the count, so this
+// only trips when the compiler cannot start at all — a missing or broken
+// .ghulproj, an unresolved compiler tool, an immediate crash.
+export const MAX_RESTART_ATTEMPTS = 5;
 
 export class ServerManager {
 	child: ChildProcess;
 	expecting_exit: boolean;
 
 	event_emitter: ServerEventEmitter;
+	connection: Connection;
 
 	server_state: ServerState;
 	ghul_config: GhulConfig;
@@ -38,15 +51,22 @@ export class ServerManager {
 	edit_queue: EditQueue;
 	response_parser: ResponseParser;
 
+	restart_attempts: number;
+	restart_timer: NodeJS.Timeout;
+
 	constructor(
 		config_event_source: ConfigEventEmitter,
 		event_emitter: ServerEventEmitter,
 		edit_queue: EditQueue,
-		response_parser: ResponseParser
+		response_parser: ResponseParser,
+		connection?: Connection
 	) {
 		this.event_emitter = event_emitter;
 		this.edit_queue = edit_queue;
 		this.response_parser = response_parser;
+		this.connection = connection;
+
+		this.restart_attempts = 0;
 
 		config_event_source.onConfigAvailable((workspace: string, config: GhulConfig) => {
 			this.workspace_root = workspace;
@@ -55,11 +75,21 @@ export class ServerManager {
 		});
 	}
 
+	// Entry point for a fresh configuration. A new config means the user (or
+	// the tooling) has changed something, so any earlier give-up is forgiven:
+	// reset the back-off budget and try again from scratch.
 	start() {
+		this.clearRestartTimer();
+		this.restart_attempts = 0;
+
+		this.launch();
+	}
+
+	private launch() {
 		this.event_emitter.starting();
 
 		this.server_state = ServerState.StartingUp;
-	
+
 		let ghul_compiler = this.ghul_config.compiler;
 
 		if (this.child) {
@@ -75,14 +105,53 @@ export class ServerManager {
 			return;
 		}
 
+		// A retry storm cannot recover from a compiler that was never
+		// resolved — spawning undefined would just throw. Surface the reason
+		// and wait for a corrected configuration.
+		if (!ghul_compiler || ghul_compiler.length == 0) {
+			this.fail(
+				"ghūl language extension: no ghūl compiler could be found. " +
+				(this.ghul_config.problems?.length
+					? this.ghul_config.problems.join("; ")
+					: "Install the ghul.compiler tool or set 'compiler' in ghul.json.")
+			);
+			return;
+		}
+
 		writeFileSync(".analysis.rsp", quote(this.ghul_config.arguments));
 
 		log(`compiler is "${quote(ghul_compiler)}"`);
 
 		this.child = spawn(ghul_compiler[0], [...ghul_compiler.slice(1), "@.analysis.rsp"]);
 
+		// 'error' (e.g. the compiler binary is missing) and 'exit' (the
+		// compiler started then died) are both failure routes for this
+		// launch. Guard so a single launch is only counted once.
+		let failure_handled = false;
+
+		const onChildFailure = (description: string) => {
+			if (failure_handled) {
+				return;
+			}
+			failure_handled = true;
+
+			this.child = null;
+
+			resolveAllPendingPromises();
+			this.edit_queue.reset();
+
+			log(description);
+
+			this.scheduleRestart();
+		};
+
 		this.child.on("error", err => {
-			log(`compiler: failed to start: ${err.message}`);			
+			if (this.expecting_exit) {
+				log(`compiler: error after expected exit: ${err.message}`);
+				return;
+			}
+
+			onChildFailure(`compiler: failed to start: ${err.message}`);
 		});
 
 		log(`spawned compiler process PID ${this.child.pid}`);
@@ -98,32 +167,72 @@ export class ServerManager {
 		this.event_emitter.running(this.child);
 
 		const pid = this.child?.pid;
-	
+
 		this.child.on('exit',
 			(_code: number, _signal: string) => {
 				const was_expecting_exit = this.expecting_exit;
 
-				if (!was_expecting_exit) {
-					log(`compiler PID ${pid}: unexpected exit`);
-				} else {
+				if (was_expecting_exit) {
 					log(`compiler PID ${pid}: exited`);
-				}
-
-				this.child = null;
-
-				resolveAllPendingPromises();
-
-				if (!was_expecting_exit) {
-					this.edit_queue.reset();
-					log(`compiler PID ${pid}: will restart after unexpected exit`);
-		
-					this.start();
-				} else {
+					this.child = null;
+					resolveAllPendingPromises();
 					this.expecting_exit = false;
+					return;
 				}
+
+				onChildFailure(`compiler PID ${pid}: unexpected exit`);
 			});
-	}	
-	
+	}
+
+	// Decide whether to try the compiler again after a failed launch, applying
+	// an exponential back-off so a persistently-broken project does not turn
+	// into a spawn loop (which VS Code eventually responds to by killing the
+	// extension host). After MAX_RESTART_ATTEMPTS we stop and wait for a
+	// configuration change.
+	private scheduleRestart() {
+		this.clearRestartTimer();
+
+		this.restart_attempts++;
+
+		if (this.restart_attempts > MAX_RESTART_ATTEMPTS) {
+			this.fail(
+				"ghūl language extension: the ghūl compiler failed to start repeatedly and will not be retried automatically. " +
+				"Check the ghūl project file and compiler configuration — saving a project file will retry."
+			);
+			return;
+		}
+
+		const delay = this.restart_attempts == 1
+			? 0
+			: Math.min(2000 * 2 ** (this.restart_attempts - 2), 16000);
+
+		log(`compiler: will restart (attempt ${this.restart_attempts} of ${MAX_RESTART_ATTEMPTS}) in ${delay}ms`);
+
+		this.restart_timer = setTimeout(() => {
+			this.restart_timer = null;
+			this.launch();
+		}, delay);
+	}
+
+	private clearRestartTimer() {
+		if (this.restart_timer) {
+			clearTimeout(this.restart_timer);
+			this.restart_timer = null;
+		}
+	}
+
+	// Stop trying and tell the user. We stay in the Failed state until a fresh
+	// configuration arrives via onConfigAvailable, which resets everything.
+	private fail(message: string) {
+		this.clearRestartTimer();
+
+		this.server_state = ServerState.Failed;
+
+		log(message);
+
+		this.connection?.window?.showErrorMessage(message);
+	}
+
 	state() {
 		return this.server_state;
 	}
@@ -132,6 +241,10 @@ export class ServerManager {
 		if (this.server_state == ServerState.Blocked) {
 			return;
 		}
+
+		// The compiler came up cleanly: a later crash gets a fresh retry
+		// budget rather than counting against this successful run.
+		this.restart_attempts = 0;
 
 		this.server_state = ServerState.Listening;
 
@@ -153,13 +266,15 @@ export class ServerManager {
 
 		log("killing any running compiler...");
 
+		this.clearRestartTimer();
+
 		try {
 			this.expecting_exit = true;
 			this.child.kill();
 			this.event_emitter.killed();
 			log("finished killing compiler");
 		} catch (e) {
-			log("killing compiler caught: " + e);			
+			log("killing compiler caught: " + e);
 			this.abort();
 		}
 	}

--- a/server/tests/connection-event-handler.test.ts
+++ b/server/tests/connection-event-handler.test.ts
@@ -80,6 +80,10 @@ describe('ConnectionEventHandler', () => {
             onReferences: jest.fn(),
             onImplementation: jest.fn(),
             onRenameRequest: jest.fn(),
+            window: {
+                showErrorMessage: jest.fn(),
+                showWarningMessage: jest.fn(),
+            },
         } as any as Connection;
 
         serverManager = {
@@ -200,6 +204,55 @@ describe('ConnectionEventHandler', () => {
 
         expect(restoreOrder).toBeLessThan(generateOrder);
         expect(generateOrder).toBeLessThan(configOrder);
+    });
+
+    it('surfaces a warning when the config loaded with problems but is still runnable', () => {
+        // A degraded load — e.g. a malformed .assemblies.json — still has a
+        // usable compiler, so analysis proceeds but the user is told why it
+        // may be incomplete.
+        jest.spyOn(restoreDotNetTools, 'restoreDotNetTools').mockReturnValue(null);
+        jest.spyOn(generateAssembliesJson, 'generateAssembliesJson').mockReturnValue(null);
+        jest.spyOn(GetGhulConfig, 'getGhulConfig').mockReturnValue({
+            compiler: ['ghul'],
+            source: ['test.ghul'],
+            arguments: [],
+            want_plaintext_hover: false,
+            problems: ['could not load .assemblies.json: unexpected token'],
+        } as GhulConfig);
+
+        jest.spyOn(DocumentChangeTrackerModule, 'DocumentChangeTracker').mockImplementation(() => ({
+            onDidChangeWatchedFiles: jest.fn(),
+        } as any as DocumentChangeTracker));
+        jest.spyOn(configEventEmitter, 'configAvailable').mockImplementation();
+
+        connectionEventHandler.workspace_root = '/path/to/workspace';
+        connectionEventHandler.initialize();
+
+        expect(connection.window.showWarningMessage).toHaveBeenCalledTimes(1);
+        const [message] = (connection.window.showWarningMessage as jest.Mock).mock.calls[0];
+        expect(message).toContain('.assemblies.json');
+    });
+
+    it('does not warn when the config loaded cleanly', () => {
+        jest.spyOn(restoreDotNetTools, 'restoreDotNetTools').mockReturnValue(null);
+        jest.spyOn(generateAssembliesJson, 'generateAssembliesJson').mockReturnValue(null);
+        jest.spyOn(GetGhulConfig, 'getGhulConfig').mockReturnValue({
+            compiler: ['ghul'],
+            source: ['test.ghul'],
+            arguments: [],
+            want_plaintext_hover: false,
+            problems: [],
+        } as GhulConfig);
+
+        jest.spyOn(DocumentChangeTrackerModule, 'DocumentChangeTracker').mockImplementation(() => ({
+            onDidChangeWatchedFiles: jest.fn(),
+        } as any as DocumentChangeTracker));
+        jest.spyOn(configEventEmitter, 'configAvailable').mockImplementation();
+
+        connectionEventHandler.workspace_root = '/path/to/workspace';
+        connectionEventHandler.initialize();
+
+        expect(connection.window.showWarningMessage).not.toHaveBeenCalled();
     });
 
     it('should handle onInitialize event', () => {

--- a/server/tests/ghul-config.test.ts
+++ b/server/tests/ghul-config.test.ts
@@ -237,4 +237,66 @@ describe('getGhulConfig', () => {
         // Compiler must come from ghul.json (or fallback), not the proj files:
         expect(cfg.compiler).toEqual(['from-json']);
     });
+
+    describe('problem reporting', () => {
+        // getGhulConfig must never throw on bad input: a malformed file or a
+        // missing compiler becomes a recorded problem so the caller can back
+        // off and surface a diagnostic, rather than crashing the server.
+
+        it('records no problems for a cleanly-configured workspace', () => {
+            const workspace = ws();
+            writeJson(workspace, 'ghul.json', { compiler: ['c'], source: ['src'] });
+
+            const cfg = getGhulConfig(workspace);
+            expect(cfg.problems).toEqual([]);
+        });
+
+        it('records a problem for malformed ghul.json instead of throwing', () => {
+            const workspace = ws();
+            writeFileSync(join(workspace, 'ghul.json'), '{ this is not json');
+
+            let cfg!: ReturnType<typeof getGhulConfig>;
+            expect(() => { cfg = getGhulConfig(workspace); }).not.toThrow();
+            expect(cfg.problems.some(p => p.includes('ghul.json'))).toBe(true);
+        });
+
+        it('records a problem for an unparseable .ghulproj instead of throwing', () => {
+            const workspace = ws();
+            writeFileSync(join(workspace, 'test.ghulproj'), '<Project><not-closed>');
+
+            let cfg!: ReturnType<typeof getGhulConfig>;
+            expect(() => { cfg = getGhulConfig(workspace); }).not.toThrow();
+            expect(cfg.problems.some(p => p.includes('test.ghulproj'))).toBe(true);
+        });
+
+        it('records a problem for malformed .assemblies.json instead of throwing', () => {
+            const workspace = ws();
+            writeJson(workspace, 'ghul.json', { compiler: ['c'], source: ['src'] });
+            writeFileSync(join(workspace, '.assemblies.json'), 'not json at all');
+
+            let cfg!: ReturnType<typeof getGhulConfig>;
+            expect(() => { cfg = getGhulConfig(workspace); }).not.toThrow();
+            expect(cfg.problems.some(p => p.includes('.assemblies.json'))).toBe(true);
+        });
+
+        it('records a problem for malformed .config/dotnet-tools.json instead of throwing', () => {
+            const workspace = ws();
+            mkdirSync(join(workspace, '.config'));
+            writeFileSync(join(workspace, '.config/dotnet-tools.json'), '{ broken');
+
+            let cfg!: ReturnType<typeof getGhulConfig>;
+            expect(() => { cfg = getGhulConfig(workspace); }).not.toThrow();
+            expect(cfg.problems.some(p => p.includes('dotnet-tools.json'))).toBe(true);
+        });
+
+        it('records a problem when no compiler can be resolved', () => {
+            // An empty workspace has no ghul.json compiler, no tool manifest
+            // and (in the test environment) no installed ghul-compiler.
+            const workspace = ws();
+
+            const cfg = getGhulConfig(workspace);
+            expect(cfg.compiler).toBeUndefined();
+            expect(cfg.problems.some(p => p.includes('compiler'))).toBe(true);
+        });
+    });
 });

--- a/server/tests/server-manager.test.ts
+++ b/server/tests/server-manager.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { writeFileSync } from 'fs';
 import { spawn } from 'child_process';
 
-import { ServerManager, ServerState } from '../src/server-manager';
+import { ServerManager, ServerState, MAX_RESTART_ATTEMPTS } from '../src/server-manager';
 import { ServerEventEmitter } from '../src/server-event-emitter';
 import { ConfigEventEmitter } from '../src/config-event-emitter';
 import { EditQueue } from '../src/edit-queue';
@@ -39,16 +39,27 @@ describe('ServerManager (state helpers)', () => {
     let manager: ServerManager;
     let serverEvents: ServerEventEmitter;
     let configEvents: ConfigEventEmitter;
+    let connection: any;
 
     beforeEach(() => {
         serverEvents = new ServerEventEmitter();
         configEvents = new ConfigEventEmitter();
+
+        // The diagnostic channel: ServerManager calls connection.window.show*
+        // when it has to refuse to spawn or gives up retrying.
+        connection = {
+            window: {
+                showErrorMessage: jest.fn(),
+                showWarningMessage: jest.fn(),
+            },
+        };
 
         manager = new ServerManager(
             configEvents,
             serverEvents,
             {} as EditQueue,
             {} as ResponseParser,
+            connection,
         );
     });
 
@@ -72,6 +83,14 @@ describe('ServerManager (state helpers)', () => {
 
             expect(manager.state()).toBe(ServerState.Blocked);
             expect(handler).not.toHaveBeenCalled();
+        });
+
+        it('resets the restart budget — a healthy run forgives earlier failures', () => {
+            manager.restart_attempts = 3;
+
+            manager.startListening();
+
+            expect(manager.restart_attempts).toBe(0);
         });
     });
 
@@ -129,6 +148,15 @@ describe('ServerManager (state helpers)', () => {
             expect(manager.expecting_exit).toBe(true);
             expect((manager.child!.kill as jest.Mock)).toHaveBeenCalled();
         });
+
+        it('cancels a pending back-off restart so it cannot fire after shutdown', () => {
+            manager.child = { kill: jest.fn() } as any;
+            manager.restart_timer = setTimeout(() => { /* would relaunch */ }, 10000);
+
+            manager.kill();
+
+            expect(manager.restart_timer).toBeNull();
+        });
     });
 
     describe('killQuiet', () => {
@@ -151,9 +179,15 @@ describe('ServerManager (state helpers)', () => {
             source: ['./**/*.ghul'],
             arguments: ['-a', '/path/to/A.dll', '-a', '/path/to/B.dll', '-A'],
             want_plaintext_hover: false,
+            problems: [],
         };
 
         beforeEach(() => {
+            // Restart back-off uses setTimeout; fake timers keep the tests
+            // deterministic and stop a scheduled relaunch leaking into the
+            // next test.
+            jest.useFakeTimers();
+
             (writeFileSync as jest.Mock).mockClear();
             (spawn as jest.Mock).mockClear().mockImplementation(() => makeFakeChild());
             manager.ghul_config = { ...baseConfig };
@@ -174,6 +208,8 @@ describe('ServerManager (state helpers)', () => {
             // requester.test.ts hits the same hazard: leaving the watchdog
             // armed can fire after the test ends and crash the worker.
             ExtensionState.getInstance().watchdog.clearWatchdog();
+            jest.clearAllTimers();
+            jest.useRealTimers();
         });
 
         it('writes .analysis.rsp with shell-quoted arguments', () => {
@@ -292,23 +328,39 @@ describe('ServerManager (state helpers)', () => {
             expect(handleChunkSpy).toHaveBeenCalledWith('LISTEN\n\f');
         });
 
-        it('on unexpected exit, resets edit queue and respawns', () => {
+        it('refuses to spawn and reports a diagnostic when no compiler is resolved', () => {
+            // A missing/unloadable .ghulproj can leave getGhulConfig with no
+            // compiler; spawning undefined would throw and crash the server.
+            manager.ghul_config = {
+                ...baseConfig,
+                compiler: undefined as unknown as string[],
+                problems: ['no usable ghūl compiler found'],
+            };
+
+            manager.start();
+
+            expect(spawn).not.toHaveBeenCalled();
+            expect(manager.state()).toBe(ServerState.Failed);
+            expect(connection.window.showErrorMessage).toHaveBeenCalledTimes(1);
+            // The recorded problem is surfaced to the user verbatim:
+            expect((connection.window.showErrorMessage as jest.Mock).mock.calls[0][0])
+                .toContain('no usable ghūl compiler found');
+        });
+
+        it('on unexpected exit, resets edit queue and respawns after back-off', () => {
             const resetSpy = jest.fn();
             manager.edit_queue = { reset: resetSpy } as unknown as EditQueue;
-
-            const firstChild = makeFakeChild(1001);
-            const secondChild = makeFakeChild(1002);
-            (spawn as jest.Mock)
-                .mockImplementationOnce(() => firstChild)
-                .mockImplementationOnce(() => secondChild);
 
             manager.start();
             // Simulate the compiler crashing without the manager having
             // asked it to exit:
             manager.expecting_exit = false;
-            firstChild.emit('exit', 1, null);
+            manager.child!.emit('exit', 1, null);
 
             expect(resetSpy).toHaveBeenCalled();
+            // The first retry is scheduled with zero delay but still async:
+            expect(spawn).toHaveBeenCalledTimes(1);
+            jest.advanceTimersByTime(0);
             expect(spawn).toHaveBeenCalledTimes(2);
         });
 
@@ -316,17 +368,95 @@ describe('ServerManager (state helpers)', () => {
             const resetSpy = jest.fn();
             manager.edit_queue = { reset: resetSpy } as unknown as EditQueue;
 
-            const child = makeFakeChild(2002);
-            (spawn as jest.Mock).mockImplementationOnce(() => child);
-
             manager.start();
             manager.expecting_exit = true;
-            child.emit('exit', 0, null);
+            manager.child!.emit('exit', 0, null);
+
+            jest.advanceTimersByTime(60000);
 
             expect(resetSpy).not.toHaveBeenCalled();
             expect(spawn).toHaveBeenCalledTimes(1);
             // expecting_exit must be cleared so the next manual kill works:
             expect(manager.expecting_exit).toBe(false);
+        });
+
+        it('applies exponential back-off between successive failed restarts', () => {
+            manager.edit_queue = { reset: jest.fn() } as unknown as EditQueue;
+
+            manager.start();
+
+            // First failure: attempt 1, zero delay.
+            manager.expecting_exit = false;
+            manager.child!.emit('exit', 1, null);
+            jest.advanceTimersByTime(0);
+            expect(spawn).toHaveBeenCalledTimes(2);
+
+            // Second failure: attempt 2, 2000ms delay — not before, then after.
+            manager.expecting_exit = false;
+            manager.child!.emit('exit', 1, null);
+            jest.advanceTimersByTime(1999);
+            expect(spawn).toHaveBeenCalledTimes(2);
+            jest.advanceTimersByTime(1);
+            expect(spawn).toHaveBeenCalledTimes(3);
+        });
+
+        it('treats a spawn error event as a failed launch and backs off', () => {
+            manager.edit_queue = { reset: jest.fn() } as unknown as EditQueue;
+
+            manager.start();
+
+            // ENOENT-style: the compiler binary is missing — 'error' fires,
+            // 'exit' never does.
+            manager.expecting_exit = false;
+            manager.child!.emit('error', new Error('spawn ENOENT'));
+            jest.advanceTimersByTime(0);
+
+            expect(spawn).toHaveBeenCalledTimes(2);
+        });
+
+        it('gives up and reports a diagnostic after repeated failures', () => {
+            manager.edit_queue = { reset: jest.fn() } as unknown as EditQueue;
+
+            manager.start();
+
+            // Fail every launch. After MAX_RESTART_ATTEMPTS retries the
+            // manager stops trying rather than spawn-looping forever.
+            for (let i = 0; i <= MAX_RESTART_ATTEMPTS; i++) {
+                expect(manager.child).not.toBeNull();
+                manager.expecting_exit = false;
+                manager.child!.emit('exit', 1, null);
+                jest.advanceTimersByTime(60000);
+            }
+
+            expect(manager.state()).toBe(ServerState.Failed);
+            expect(manager.child).toBeNull();
+            expect(connection.window.showErrorMessage).toHaveBeenCalledTimes(1);
+
+            // No further restarts once it has given up:
+            const spawnsAtGiveUp = (spawn as jest.Mock).mock.calls.length;
+            jest.advanceTimersByTime(120000);
+            expect((spawn as jest.Mock).mock.calls.length).toBe(spawnsAtGiveUp);
+        });
+
+        it('a fresh configuration forgives an earlier give-up and retries', () => {
+            manager.edit_queue = { reset: jest.fn() } as unknown as EditQueue;
+
+            manager.start();
+            for (let i = 0; i <= MAX_RESTART_ATTEMPTS; i++) {
+                manager.expecting_exit = false;
+                manager.child!.emit('exit', 1, null);
+                jest.advanceTimersByTime(60000);
+            }
+            expect(manager.state()).toBe(ServerState.Failed);
+
+            // The user fixes the project — start() runs again (driven by a
+            // new config-available event); the manager resets and relaunches.
+            const spawnsBefore = (spawn as jest.Mock).mock.calls.length;
+            manager.start();
+
+            expect(manager.restart_attempts).toBe(0);
+            expect(manager.state()).toBe(ServerState.StartingUp);
+            expect((spawn as jest.Mock).mock.calls.length).toBe(spawnsBefore + 1);
         });
     });
 });


### PR DESCRIPTION
Bugs fixed:
- The language server restarted the compiler in an unbounded loop when it could not start (missing or unloadable `.ghulproj`, unresolved compiler tool, immediate crash); a broken project file could also throw out of config loading and crash the extension host until VS Code stopped restarting it. Failed launches now retry with exponential back-off, give up after five attempts, and recover automatically when a project file is saved.
- Compiler-configuration problems are no longer silent — an unresolved compiler or a give-up after repeated failures is reported as a VS Code error, a degraded-but-runnable load as a warning.