### PR TITLE
Recover a hung compiler; keep unsaved edits across a recycle

### DIFF
--- a/server/src/extension-state.ts
+++ b/server/src/extension-state.ts
@@ -81,8 +81,6 @@ export class ExtensionState {
     }
 
     public connect() {
-        this.watchdog = new Watchdog(10000);
-
         this.server_event_emitter = new ServerEventEmitter();
         this.config_event_emitter = new ConfigEventEmitter();
         
@@ -96,15 +94,18 @@ export class ExtensionState {
         this.requester = new Requester(this.server_event_emitter, this.response_handler);
         
         this.edit_queue = new EditQueue(this.requester);
-        
+
+        this.documents = new TextDocuments(TextDocument);
+
         new GhulAnalyser(
             this.edit_queue,
             this.config_event_emitter,
-            this.server_event_emitter
+            this.server_event_emitter,
+            this.documents
         );
-        
+
         this.response_parser = new ResponseParser(this.response_handler);
-        
+
         this.server_manager = new ServerManager(
             this.config_event_emitter,
             this.server_event_emitter,
@@ -112,12 +113,14 @@ export class ExtensionState {
             this.response_parser,
             this.connection
         );
-        
+
+        // Created after the server manager so its timeout can hand off to it:
+        // a wedged compiler is killed and relaunched.
+        this.watchdog = new Watchdog(10000, () => this.server_manager.recoverFromHang());
+
         this.response_handler.setServerManager(this.server_manager);
         this.response_handler.setEditQueue(this.edit_queue);
 
-        this.documents = new TextDocuments(TextDocument);
-        
         this.documents.onDidChangeContent((change) => {
             this.edit_queue.queueEdit(change);
         });

--- a/server/src/ghul-analyser.ts
+++ b/server/src/ghul-analyser.ts
@@ -6,12 +6,16 @@ import { URL, pathToFileURL, fileURLToPath } from 'url';
 
 import { globSync } from 'glob';
 
-import { GhulConfig } from './ghul-config'; 
+import { TextDocuments } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { GhulConfig } from './ghul-config';
 
 import { ConfigEventEmitter } from './config-event-emitter';
 
 import { ServerEventEmitter } from './server-event-emitter';
 import { EditQueue } from './edit-queue';
+import { normalizeFileUri } from './normalize-file-uri';
 
 export class GhulAnalyser {
     server_event_emitter: ServerEventEmitter;
@@ -19,14 +23,17 @@ export class GhulAnalyser {
     workspace_root: string;
     edit_queue: EditQueue;
     ghul_config: GhulConfig;
+    documents: TextDocuments<TextDocument>;
 
     constructor(
         edit_queue: EditQueue,
 
         config_event_emitter: ConfigEventEmitter,
-        server_event_emitter: ServerEventEmitter
+        server_event_emitter: ServerEventEmitter,
+        documents: TextDocuments<TextDocument>
     ) {
         this.edit_queue = edit_queue;
+        this.documents = documents;
 
         this.server_event_emitter = server_event_emitter;
 
@@ -54,11 +61,23 @@ export class GhulAnalyser {
                 );
         });
 
-        let documents = sourceFiles.map((uri: URL) => {
-            let path = fileURLToPath(uri);
-            let source =  readFileSync(path).toString();
+        // An open editor buffer can hold edits the user has not saved. Prefer
+        // it over the file on disk so the analyser — on first analyse and on
+        // every recycle — sees what the user is actually looking at.
+        let open_source_by_uri = new Map<string, string>();
 
+        for (let document of this.documents.all()) {
+            open_source_by_uri.set(normalizeFileUri(document.uri), document.getText());
+        }
+
+        let documents = sourceFiles.map((uri: URL) => {
             let mapped = uri.toString();
+
+            let open_source = open_source_by_uri.get(normalizeFileUri(mapped));
+
+            let source = open_source !== undefined
+                ? open_source
+                : readFileSync(fileURLToPath(uri)).toString();
 
             return {
                 uri: mapped,

--- a/server/src/response-handler.ts
+++ b/server/src/response-handler.ts
@@ -182,19 +182,6 @@ export class ResponseHandler {
         this.server_manager.startListening();
     }
 
-    handleExcept(lines: string[]) {
-        var error = '';
-
-        for (let l of lines) {
-            error += l;
-            log(l);
-        }
-
-        this.server_manager.abort();
-
-        this.connection.window.showErrorMessage(error);
-    }
-
     handleDiagnostics(lines: string[]) {
         for (let diagnostic of this.parseDiagnostics(lines)) {
             this.connection.sendDiagnostics( {uri: diagnostic[0], diagnostics: diagnostic[1]})
@@ -560,6 +547,7 @@ export class ResponseHandler {
 
     handleRestart() {
         log("compiler requested restart");
+        this.server_manager.noteRecycle();
         this.edit_queue.reset();
     }
     

--- a/server/src/response-parser.ts
+++ b/server/src/response-parser.ts
@@ -113,12 +113,6 @@ export class ResponseParser {
             clearWatchdog();
 
             this.response_handler.handleSymbols(lines);
-            break;            
-            
-        case "EXCEPT":
-            clearWatchdog();
-
-            this.response_handler.handleExcept(lines);
             break;
 
         case "REFERENCES":

--- a/server/src/server-manager.ts
+++ b/server/src/server-manager.ts
@@ -9,7 +9,7 @@ import {
 import { Connection } from 'vscode-languageserver';
 
 import { log } from './log';
-import { resolveAllPendingPromises } from './extension-state';
+import { rejectAllPendingPromises, resolveAllPendingPromises } from './extension-state';
 
 import { GhulConfig } from './ghul-config';
 
@@ -41,6 +41,7 @@ export const MAX_RESTART_ATTEMPTS = 5;
 export class ServerManager {
 	child: ChildProcess;
 	expecting_exit: boolean;
+	expecting_recycle: boolean;
 
 	event_emitter: ServerEventEmitter;
 	connection: Connection;
@@ -170,13 +171,25 @@ export class ServerManager {
 
 		this.child.on('exit',
 			(_code: number, _signal: string) => {
-				const was_expecting_exit = this.expecting_exit;
-
-				if (was_expecting_exit) {
+				if (this.expecting_exit) {
 					log(`compiler PID ${pid}: exited`);
 					this.child = null;
 					resolveAllPendingPromises();
 					this.expecting_exit = false;
+					return;
+				}
+
+				// A recycle is a planned exit — the compiler asked to be
+				// restarted (RESTART frame) to shed accumulated memory. It is
+				// healthy, so relaunch at once without spending the crash
+				// back-off budget.
+				if (this.expecting_recycle) {
+					this.expecting_recycle = false;
+					log(`compiler PID ${pid}: recycled — relaunching`);
+					this.child = null;
+					resolveAllPendingPromises();
+					this.edit_queue.reset();
+					this.launch();
 					return;
 				}
 
@@ -276,6 +289,28 @@ export class ServerManager {
 		} catch (e) {
 			log("killing compiler caught: " + e);
 			this.abort();
+		}
+	}
+
+	// The compiler announced a planned recycle with a RESTART frame and is
+	// about to exit. Mark the coming exit deliberate so it relaunches cleanly
+	// rather than being treated as a crash.
+	noteRecycle() {
+		this.expecting_recycle = true;
+	}
+
+	// The watchdog fired: the compiler has stopped answering but has not
+	// exited. Kill it so the 'exit' handler routes through normal crash
+	// recovery (back-off included — a wedged compiler may wedge again).
+	recoverFromHang() {
+		rejectAllPendingPromises("ghūl language extension: compiler watchdog timeout");
+
+		if (this.child) {
+			log(`compiler PID ${this.child.pid}: unresponsive — killing`);
+			this.child.kill();
+		} else {
+			log("compiler watchdog timeout with no running compiler — scheduling restart");
+			this.scheduleRestart();
 		}
 	}
 

--- a/server/src/watchdog.ts
+++ b/server/src/watchdog.ts
@@ -1,35 +1,17 @@
+import { log } from './log';
 
-import { rejectAllAndThrow } from './extension-state';
-
-/*
-type Timer = NodeJS.Timeout & { getRemainingTime: () => number };
-
-function createTimer(callback: () => void, delay: number): Timer {
-    const startTime = Date.now();
-    const timer = setTimeout(callback, delay) as Timer;
-
-    timer.getRemainingTime = () => {
-        const currentTime = Date.now();
-        const elapsedTime = currentTime - startTime;
-        return Math.max(delay - elapsedTime, 0);
-    };
-
-    return timer;
-}
-*/
-
-type Timer = NodeJS.Timeout;
-
-function createTimer(callback: () => void, delay: number): Timer {
-    return setTimeout(callback, delay);
-}
-
+// Bounds how long the extension waits for the compiler to answer a request.
+// The timer is (re)started when a request is sent and cleared when any frame
+// comes back; if it fires, the compiler is wedged — it has neither answered
+// nor crashed — and the recovery callback kills and relaunches it.
 export class Watchdog {
-    watchdog_timer: Timer;
+    watchdog_timer: NodeJS.Timeout;
     timeout_milliseconds: number;
+    private on_timeout: () => void;
 
-    constructor(timeout_milliseconds: number) {
+    constructor(timeout_milliseconds: number, on_timeout: () => void) {
         this.timeout_milliseconds = timeout_milliseconds;
+        this.on_timeout = on_timeout;
     }
 
     setTimeout(timeout_milliseconds: number) {
@@ -43,22 +25,29 @@ export class Watchdog {
     }
 
     startWatchdog() {
-        this.watchdog_timer = createTimer(() => { this.onWatchdogTimeout() }, this.timeout_milliseconds);
+        this.watchdog_timer = setTimeout(() => { this.onWatchdogTimeout(); }, this.timeout_milliseconds);
     }
 
     resetWatchdog() {
         this.clearWatchdog();
         this.startWatchdog();
     }
-    
+
     clearWatchdog() {
         if (this.watchdog_timer) {
             clearTimeout(this.watchdog_timer);
             this.watchdog_timer = null;
         }
     }
-    
-    onWatchdogTimeout() {
-        rejectAllAndThrow("ghūl language extension: compiler watchdog timeout");
-    }    
+
+    // The compiler has not answered within the timeout. A crash would have
+    // fired the process 'exit' handler instead, so this is a wedge: nothing
+    // recovers it on its own. Hand off to the recovery callback.
+    private onWatchdogTimeout() {
+        this.watchdog_timer = null;
+
+        log("ghūl language extension: compiler watchdog timeout");
+
+        this.on_timeout();
+    }
 }

--- a/server/tests/edit-queue.test.ts
+++ b/server/tests/edit-queue.test.ts
@@ -34,7 +34,7 @@ describe('EditQueue', () => {
         jest.useFakeTimers();
         // Watchdog gets touched via setWatchdogTimeout/getWatchdogTimeout from
         // edit-queue. Wire a real one so those calls don't NPE.
-        ExtensionState.getInstance().watchdog = new Watchdog(10000);
+        ExtensionState.getInstance().watchdog = new Watchdog(10000, () => {});
 
         recorder = new RecordingRequester();
         queue = new EditQueue(recorder as unknown as Requester);

--- a/server/tests/extension-state.test.ts
+++ b/server/tests/extension-state.test.ts
@@ -27,7 +27,7 @@ describe('extension-state module-level helpers', () => {
     beforeEach(() => {
         jest.useFakeTimers();
         const state = ExtensionState.getInstance();
-        watchdog = new Watchdog(2500);
+        watchdog = new Watchdog(2500, () => {});
         state.watchdog = watchdog;
         responseHandler = new ResponseHandler({} as Connection, new ConfigEventEmitter());
         state.response_handler = responseHandler;

--- a/server/tests/ghul-analyser.test.ts
+++ b/server/tests/ghul-analyser.test.ts
@@ -1,6 +1,10 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+import { TextDocuments } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { GhulAnalyser } from '../src/ghul-analyser';
 import { ConfigEventEmitter } from '../src/config-event-emitter';
@@ -13,6 +17,13 @@ class RecordingEditQueue {
     start(documents: { uri: string; source: string }[]) {
         this.started.push(documents);
     }
+}
+
+// A stand-in for the LSP TextDocuments store: GhulAnalyser only calls .all().
+function fakeDocuments(open: { uri: string; text: string }[] = []) {
+    return {
+        all: () => open.map(d => ({ uri: d.uri, getText: () => d.text })),
+    } as unknown as TextDocuments<TextDocument>;
 }
 
 describe('GhulAnalyser', () => {
@@ -37,6 +48,7 @@ describe('GhulAnalyser', () => {
             editQueue as unknown as EditQueue,
             configEvents,
             serverEvents,
+            fakeDocuments(),
         );
 
         const config: GhulConfig = {
@@ -65,6 +77,7 @@ describe('GhulAnalyser', () => {
             editQueue as unknown as EditQueue,
             configEvents,
             serverEvents,
+            fakeDocuments(),
         );
 
         configEvents.configAvailable(workspace, {
@@ -86,11 +99,39 @@ describe('GhulAnalyser', () => {
         expect(editQueue.started[0].find(d => d.uri.endsWith('a.ghul'))!.source).toBe('class A is {}');
     });
 
+    it('prefers an open editor buffer over the file on disk', () => {
+        writeFileSync(join(workspace, 'a.ghul'), 'class A is {} // on disk');
+
+        const uri = pathToFileURL(join(workspace, 'a.ghul')).toString();
+
+        new GhulAnalyser(
+            editQueue as unknown as EditQueue,
+            configEvents,
+            serverEvents,
+            fakeDocuments([{ uri, text: 'class A is {} // unsaved buffer' }]),
+        );
+
+        configEvents.configAvailable(workspace, {
+            block: false,
+            compiler: ['c'],
+            source: [`${workspace}/**/*.ghul`],
+            arguments: [],
+            want_plaintext_hover: false,
+        });
+
+        serverEvents.listening();
+
+        expect(editQueue.started).toHaveLength(1);
+        expect(editQueue.started[0]).toHaveLength(1);
+        expect(editQueue.started[0][0].source).toBe('class A is {} // unsaved buffer');
+    });
+
     it('starts edit queue with an empty document list when no source files match', () => {
         new GhulAnalyser(
             editQueue as unknown as EditQueue,
             configEvents,
             serverEvents,
+            fakeDocuments(),
         );
 
         configEvents.configAvailable(workspace, {

--- a/server/tests/requester.test.ts
+++ b/server/tests/requester.test.ts
@@ -43,7 +43,7 @@ describe('Requester', () => {
     let requester: Requester;
 
     beforeEach(() => {
-        ExtensionState.getInstance().watchdog = new Watchdog(10000);
+        ExtensionState.getInstance().watchdog = new Watchdog(10000, () => {});
 
         events = new ServerEventEmitter();
         response = new RecordingResponseHandler();

--- a/server/tests/response-handler.test.ts
+++ b/server/tests/response-handler.test.ts
@@ -167,27 +167,6 @@ jest.mock('../src/config-event-emitter');
         expect(startListeningSpy).toHaveBeenCalled();
     });
 
-    it('should abort server manager and show error message on handleExcept', () => {
-        responseHandler.server_manager = {
-            abort: () => {}
-        } as ServerManager;
-
-        responseHandler.connection = {
-            window: {
-                showErrorMessage: () => {}
-            }
-        } as any;
-
-        const abortSpy = jest.spyOn(responseHandler.server_manager, 'abort');
-        const showErrorMessageSpy = jest.spyOn(responseHandler.connection.window, 'showErrorMessage');
-
-        const errorLines = ['Error 1', 'Error 2'];
-        responseHandler.handleExcept(errorLines);
-
-        expect(abortSpy).toHaveBeenCalled();
-        expect(showErrorMessageSpy).toHaveBeenCalledWith('Error 1Error 2');
-    });
-
     it('should send diagnostics on handleDiagnostics', () => {
         responseHandler.connection = {
             sendDiagnostics: () => {}
@@ -668,12 +647,15 @@ jest.mock('../src/config-event-emitter');
         expect(result.signatures).toEqual([]);
     });
 
-    it('handleRestart calls edit_queue.reset', () => {
+    it('handleRestart notes the recycle and resets the edit queue', () => {
         const reset = jest.fn();
+        const noteRecycle = jest.fn();
         responseHandler.edit_queue = { reset } as any;
+        responseHandler.server_manager = { noteRecycle } as any;
 
         responseHandler.handleRestart();
 
+        expect(noteRecycle).toHaveBeenCalledTimes(1);
         expect(reset).toHaveBeenCalledTimes(1);
     });
 

--- a/server/tests/response-parser.test.ts
+++ b/server/tests/response-parser.test.ts
@@ -19,7 +19,6 @@ class RecordingHandler {
     handleCompletion(lines: string[]) { this.calls.push({ method: 'handleCompletion', lines }); }
     handleSignature(lines: string[]) { this.calls.push({ method: 'handleSignature', lines }); }
     handleSymbols(lines: string[]) { this.calls.push({ method: 'handleSymbols', lines }); }
-    handleExcept(lines: string[]) { this.calls.push({ method: 'handleExcept', lines }); }
     handleReferences(lines: string[]) { this.calls.push({ method: 'handleReferences', lines }); }
     handleImplementation(lines: string[]) { this.calls.push({ method: 'handleImplementation', lines }); }
     handleRenameRequest(lines: string[]) { this.calls.push({ method: 'handleRenameRequest', lines }); }
@@ -31,7 +30,7 @@ class RecordingHandler {
 // extension-state singleton, so wire a real Watchdog + ResponseHandler in.
 function wireSingleton(): { handler: ResponseHandler } {
     const state = ExtensionState.getInstance();
-    state.watchdog = new Watchdog(1000);
+    state.watchdog = new Watchdog(1000, () => {});
 
     const connection = {} as Connection;
     const config = new ConfigEventEmitter();
@@ -84,7 +83,6 @@ describe('ResponseParser', () => {
         ['COMPLETION', 'handleCompletion'],
         ['SIGNATURE', 'handleSignature'],
         ['SYMBOLS', 'handleSymbols'],
-        ['EXCEPT', 'handleExcept'],
         ['REFERENCES', 'handleReferences'],
         ['IMPLEMENTATION', 'handleImplementation'],
         ['RENAMEREQUEST', 'handleRenameRequest'],

--- a/server/tests/server-manager.test.ts
+++ b/server/tests/server-manager.test.ts
@@ -197,7 +197,7 @@ describe('ServerManager (state helpers)', () => {
             // Wire a minimal stub so the handler doesn't throw and obscure
             // the assertions we actually want to make:
             const state = ExtensionState.getInstance();
-            state.watchdog = new Watchdog(10000);
+            state.watchdog = new Watchdog(10000, () => {});
             state.response_handler = {
                 resolveAllPendingPromises: jest.fn(),
                 rejectAllPendingPromises: jest.fn(),
@@ -362,6 +362,36 @@ describe('ServerManager (state helpers)', () => {
             expect(spawn).toHaveBeenCalledTimes(1);
             jest.advanceTimersByTime(0);
             expect(spawn).toHaveBeenCalledTimes(2);
+        });
+
+        it('on a recycle exit, relaunches at once without spending the back-off budget', () => {
+            const resetSpy = jest.fn();
+            manager.edit_queue = { reset: resetSpy } as unknown as EditQueue;
+
+            manager.start();
+
+            // The compiler announced a planned recycle (RESTART frame) and
+            // then exited deliberately.
+            manager.noteRecycle();
+            manager.expecting_exit = false;
+            manager.child!.emit('exit', 1, null);
+
+            expect(resetSpy).toHaveBeenCalled();
+            // Relaunched immediately — no scheduled-restart timer to advance:
+            expect(spawn).toHaveBeenCalledTimes(2);
+            // A recycle is healthy, so it does not count as a failed start:
+            expect(manager.restart_attempts).toBe(0);
+        });
+
+        it('recoverFromHang kills the unresponsive compiler', () => {
+            manager.edit_queue = { reset: jest.fn() } as unknown as EditQueue;
+
+            manager.start();
+            const child = manager.child!;
+
+            manager.recoverFromHang();
+
+            expect(child.kill).toHaveBeenCalled();
         });
 
         it('on expected exit, does not respawn', () => {

--- a/server/tests/watchdog.test.ts
+++ b/server/tests/watchdog.test.ts
@@ -1,25 +1,13 @@
 import { Watchdog } from '../src/watchdog';
-import { ExtensionState } from '../src/extension-state';
-import { ResponseHandler } from '../src/response-handler';
-import { ConfigEventEmitter } from '../src/config-event-emitter';
-import { Connection } from 'vscode-languageserver';
-
-// onWatchdogTimeout() calls rejectAllAndThrow() on the extension-state
-// singleton. Wire a real ResponseHandler so that path doesn't NPE.
-function wireSingletonForRejection() {
-    const state = ExtensionState.getInstance();
-    const connection = {} as Connection;
-    const config = new ConfigEventEmitter();
-    state.response_handler = new ResponseHandler(connection, config);
-}
 
 describe('Watchdog', () => {
     let watchdog: Watchdog;
+    let onTimeout: jest.Mock;
 
     beforeEach(() => {
         jest.useFakeTimers();
-        wireSingletonForRejection();
-        watchdog = new Watchdog(1000);
+        onTimeout = jest.fn();
+        watchdog = new Watchdog(1000, onTimeout);
     });
 
     afterEach(() => {
@@ -32,16 +20,16 @@ describe('Watchdog', () => {
 
         jest.advanceTimersByTime(2000);
 
-        // We can prove no throw by simply running the timer; if a timeout
-        // had fired, rejectAllAndThrow() would have thrown synchronously.
-        // (Hardened: also assert the timer slot is null.)
+        expect(onTimeout).not.toHaveBeenCalled();
         expect(watchdog.watchdog_timer).toBeNull();
     });
 
-    it('fires after the timeout, calling rejectAllAndThrow', () => {
+    it('fires the timeout handler after the timeout', () => {
         watchdog.startWatchdog();
 
-        expect(() => jest.advanceTimersByTime(1500)).toThrow(/watchdog timeout/);
+        jest.advanceTimersByTime(1500);
+
+        expect(onTimeout).toHaveBeenCalledTimes(1);
     });
 
     it('startWatchdogIfNotRunning is idempotent while a timer is set', () => {
@@ -60,10 +48,12 @@ describe('Watchdog', () => {
         jest.advanceTimersByTime(800);
 
         watchdog.resetWatchdog();
-        // 500ms after reset (and 1300 total) – pre-reset would have fired by now
+        // 500ms after reset (1300 total) — pre-reset would have fired by now:
         jest.advanceTimersByTime(500);
+        expect(onTimeout).not.toHaveBeenCalled();
 
-        expect(() => jest.advanceTimersByTime(600)).toThrow(/watchdog timeout/);
+        jest.advanceTimersByTime(600);
+        expect(onTimeout).toHaveBeenCalledTimes(1);
     });
 
     it('setTimeout clamps below 1000ms up to 1000ms', () => {


### PR DESCRIPTION
Enhancements:
- The compiler watchdog now recovers a hung analyser: on a timeout it kills the process so it is relaunched. Previously a timeout only rejected the in-flight request and left the wedged process running, unrecoverable until the window was reloaded.
- Re-analysing the project — at startup and after every recycle — now prefers open editor buffers over the files on disk, so a recycle no longer silently drops unsaved edits.

Technical:
- A planned recycle (a RESTART frame) is relaunched at once and logged as a recycle, rather than treated as a crash against the back-off budget.
- Removed the dead EXCEPT response path; the compiler never emits it.