### PR TITLE
Add document formatting support

### DIFF
--- a/server/src/connection-event-handler.ts
+++ b/server/src/connection-event-handler.ts
@@ -18,7 +18,12 @@ import {
     RenameParams,
     WorkspaceEdit,
     TextDocumentSyncKind,
+    DocumentFormattingParams,
+    TextEdit,
+    TextDocuments,
 } from 'vscode-languageserver';
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { log } from './log';
 
@@ -44,19 +49,22 @@ export class ConnectionEventHandler {
     config: GhulConfig;
     workspace_root: string;
     document_change_tracker: DocumentChangeTracker;
+    documents: TextDocuments<TextDocument>;
 
     constructor(
         connection: Connection,
         server_manager: ServerManager,
-        config_event_emitter: ConfigEventEmitter,        
+        config_event_emitter: ConfigEventEmitter,
         requester: Requester,
-        edit_queue: EditQueue
+        edit_queue: EditQueue,
+        documents: TextDocuments<TextDocument>
     ) {
         this.connection = connection;
         this.server_manager = server_manager;
         this.config_event_emitter = config_event_emitter;
         this.requester = requester;
         this.edit_queue = edit_queue;
+        this.documents = documents;
 
         connection.onInitialize((params: InitializedParams): InitializeResult => 
             this.onInitialize(params));
@@ -109,6 +117,10 @@ export class ConnectionEventHandler {
         connection.onRenameRequest(
              (params: RenameParams): Promise<WorkspaceEdit> =>
                 this.onRenameRequest(params));
+
+        connection.onDocumentFormatting(
+            (params: DocumentFormattingParams): Promise<TextEdit[]> =>
+                this.onDocumentFormatting(params));
     }
 
     initialize() {
@@ -181,7 +193,8 @@ export class ConnectionEventHandler {
                     triggerCharacters: ["(", "["]
                 },
                 implementationProvider: true,
-                renameProvider: true
+                renameProvider: true,
+                documentFormattingProvider: true
             }
         }
     }
@@ -245,5 +258,26 @@ export class ConnectionEventHandler {
 
     onRenameRequest(params: RenameParams): Promise<WorkspaceEdit> {
         return this.requester.sendRenameRequest(params.textDocument.uri, params.position.line, params.position.character, params.newName);
+    }
+
+    onDocumentFormatting(params: DocumentFormattingParams): Promise<TextEdit[]> {
+        let document = this.documents.get(params.textDocument.uri);
+
+        if (!document) {
+            return Promise.resolve([]);
+        }
+
+        // The whole document is replaced; the analyser reparses the buffer we
+        // send, so flushing pending edits first is not required for correctness.
+        let whole_document = {
+            start: { line: 0, character: 0 },
+            end: { line: document.lineCount + 1, character: 0 }
+        };
+
+        return this.requester.sendDocumentFormatting(
+            params.textDocument.uri,
+            document.getText(),
+            whole_document
+        );
     }
 }

--- a/server/src/extension-state.ts
+++ b/server/src/extension-state.ts
@@ -130,7 +130,8 @@ export class ExtensionState {
             this.server_manager,
             this.config_event_emitter,
             this.requester,
-            this.edit_queue
+            this.edit_queue,
+            this.documents
         );
 
         this.documents.listen(this.connection);

--- a/server/src/requester.ts
+++ b/server/src/requester.ts
@@ -5,7 +5,9 @@ import {
     SignatureHelp,
     SymbolInformation,
     Location,
-    WorkspaceEdit
+    WorkspaceEdit,
+    TextEdit,
+    Range
 } from 'vscode-languageserver';
 
 import { log } from './log';
@@ -211,6 +213,21 @@ export class Requester {
             this.write(newName + '\n');
 
             return this.response_handler.expectRenameRequest();
+        } else {
+            return null;
+        }
+    }
+
+    sendDocumentFormatting(uri: string, source: string, range: Range): Promise<TextEdit[]> {
+        if (this.analysed) {
+            startWatchdogIfNotRunning();
+
+            this.write('#FORMAT#\n');
+            this.write(normalizeFileUri(uri) + '\n');
+            this.write(source);
+            this.write('\f');
+
+            return this.response_handler.expectDocumentFormatting(range);
         } else {
             return null;
         }

--- a/server/src/response-handler.ts
+++ b/server/src/response-handler.ts
@@ -10,8 +10,9 @@ import {
     ParameterInformation, 
     SymbolInformation, 
     Location, 
-    WorkspaceEdit, 
-    TextEdit, 
+    WorkspaceEdit,
+    TextEdit,
+    Range,
     Diagnostic,
 } from 'vscode-languageserver';
 
@@ -112,6 +113,11 @@ export class ResponseHandler {
     _references_promise_queue: PromiseQueue<Location[]>;
     _implementation_promise_queue: PromiseQueue<Location[]>;
     _rename_promise_queue: PromiseQueue<WorkspaceEdit>;
+    _formatting_promise_queue: PromiseQueue<TextEdit[]>;
+
+    // The full-document range to replace, one per pending format request,
+    // paired FIFO with _formatting_promise_queue.
+    _formatting_ranges: Range[] = [];
 
     constructor(
         connection: Connection,
@@ -132,6 +138,7 @@ export class ResponseHandler {
         this._references_promise_queue = new PromiseQueue<Location[]>("REFERENCES");
         this._implementation_promise_queue = new PromiseQueue<Location[]>("IMPLEMENTATION");
         this._rename_promise_queue = new PromiseQueue<WorkspaceEdit>("RENAMEREQUEST");
+        this._formatting_promise_queue = new PromiseQueue<TextEdit[]>("FORMAT");
     }
 
     onConfigAvailable(_workspace: string, config: GhulConfig) {
@@ -148,6 +155,8 @@ export class ResponseHandler {
         this._references_promise_queue.resolveAll([]);
         this._implementation_promise_queue.resolveAll([]);
         this._rename_promise_queue.resolveAll(null);
+        this._formatting_promise_queue.resolveAll([]);
+        this._formatting_ranges = [];
     }
 
     rejectAllPendingPromises(message: string) {
@@ -160,6 +169,8 @@ export class ResponseHandler {
         this._references_promise_queue.rejectAll(message);
         this._implementation_promise_queue.rejectAll(message);
         this._rename_promise_queue.reject(message);
+        this._formatting_promise_queue.rejectAll(message);
+        this._formatting_ranges = [];
     }
 
     setServerManager(server_manager: ServerManager) {
@@ -544,6 +555,30 @@ export class ResponseHandler {
             resolve({});
         }
     }    
+
+    expectDocumentFormatting(range: Range): Promise<TextEdit[]> {
+        this._formatting_ranges.push(range);
+        return this._formatting_promise_queue.enqueue();
+    }
+
+    handleDocumentFormatting(lines: string[]) {
+        let {resolve} = this._formatting_promise_queue.dequeueAlways();
+        let range = this._formatting_ranges.shift();
+
+        try {
+            // The compiler returns the whole reformatted document; the parser
+            // has already stripped the FORMAT header and trailing terminator.
+            // Replace the whole document in one edit. If the compiler could
+            // not format (it echoes the buffer back unchanged), the edit is a
+            // harmless no-op.
+            let newText = lines.join('\n') + '\n';
+
+            resolve([{ range, newText }]);
+        } catch(e) {
+            log("document formatting: caught:" + e);
+            resolve([]);
+        }
+    }
 
     handleRestart() {
         log("compiler requested restart");

--- a/server/src/response-parser.ts
+++ b/server/src/response-parser.ts
@@ -139,6 +139,12 @@ export class ResponseParser {
             this.response_handler.handleRestart();
             break;
 
+        case "FORMAT":
+            clearWatchdog();
+
+            this.response_handler.handleDocumentFormatting(lines);
+            break;
+
         default:
             // not a known command, but compiler presumably still alive
             clearWatchdog();

--- a/server/tests/connection-event-handler.test.ts
+++ b/server/tests/connection-event-handler.test.ts
@@ -1,10 +1,10 @@
 import { ConnectionEventHandler } from '../src/connection-event-handler';
-import { CompletionParams, Connection, DocumentSymbolParams, InitializeResult, InitializedParams, ReferenceParams, TextDocumentPositionParams, 
-    // TextDocuments 
+import { CompletionParams, Connection, DocumentSymbolParams, InitializeResult, InitializedParams, ReferenceParams, TextDocumentPositionParams,
+    TextDocuments
 } from 'vscode-languageserver';
-// import {
-//     TextDocument
-// } from 'vscode-languageserver-textdocument';
+import {
+    TextDocument
+} from 'vscode-languageserver-textdocument';
 
 
 import { ServerManager } from '../src/server-manager';
@@ -33,6 +33,7 @@ describe('ConnectionEventHandler', () => {
     let configEventEmitter: ConfigEventEmitter;
     let requester: Requester;
     let editQueue: EditQueue;
+    let documents: TextDocuments<TextDocument>;
     let connectionEventHandler: ConnectionEventHandler;
 
     beforeEach(() => {
@@ -84,17 +85,16 @@ describe('ConnectionEventHandler', () => {
                 showErrorMessage: jest.fn(),
                 showWarningMessage: jest.fn(),
             },
+            onDocumentFormatting: jest.fn(),
         } as any as Connection;
 
         serverManager = {
             kill: jest.fn(),
         } as any as ServerManager;
 
-        // documents = {
-        //     onDidOpen: jest.fn(),
-        //     onDidClose: jest.fn(),
-        //     onDidChangeContent: jest.fn(),
-        // } as any as TextDocuments<TextDocument>;
+        documents = {
+            get: jest.fn(),
+        } as any as TextDocuments<TextDocument>;
 
         configEventEmitter = {
             onConfigAvailable: jest.fn(),
@@ -117,7 +117,7 @@ describe('ConnectionEventHandler', () => {
             sendQueued: jest.fn(),
         } as any as EditQueue;
 
-        connectionEventHandler = new ConnectionEventHandler(connection, serverManager, configEventEmitter, requester, editQueue);
+        connectionEventHandler = new ConnectionEventHandler(connection, serverManager, configEventEmitter, requester, editQueue, documents);
     });
 
     afterEach(() => {
@@ -285,7 +285,8 @@ describe('ConnectionEventHandler', () => {
                     triggerCharacters: ['(', '[']
                 },
                 implementationProvider: true,
-                renameProvider: true
+                renameProvider: true,
+                documentFormattingProvider: true
             }
         });
     });
@@ -545,6 +546,35 @@ describe('ConnectionEventHandler', () => {
         expect(result).toEqual({ changes: { 'test-uri': [] } });
     });
 
+    it('should handle onDocumentFormatting event', async () => {
+        const edit = { range: { start: { line: 0, character: 0 }, end: { line: 4, character: 0 } }, newText: 'formatted\n' };
+        const sendDocumentFormatting = jest.fn().mockResolvedValue([edit]);
+        (requester as any).sendDocumentFormatting = sendDocumentFormatting;
+        (documents.get as jest.Mock).mockReturnValue({ getText: () => 'source', lineCount: 3 });
+
+        const result = await connectionEventHandler.onDocumentFormatting({
+            textDocument: { uri: 'test-uri' },
+        } as any);
+
+        expect(sendDocumentFormatting).toHaveBeenCalledWith('test-uri', 'source', expect.objectContaining({
+            start: { line: 0, character: 0 },
+        }));
+        expect(result).toEqual([edit]);
+    });
+
+    it('onDocumentFormatting returns no edits for an untracked document', async () => {
+        const sendDocumentFormatting = jest.fn();
+        (requester as any).sendDocumentFormatting = sendDocumentFormatting;
+        (documents.get as jest.Mock).mockReturnValue(undefined);
+
+        const result = await connectionEventHandler.onDocumentFormatting({
+            textDocument: { uri: 'missing-uri' },
+        } as any);
+
+        expect(sendDocumentFormatting).not.toHaveBeenCalled();
+        expect(result).toEqual([]);
+    });
+
     describe('connection.onX callbacks registered by constructor', () => {
         // The constructor wires each connection.onX with an inline arrow that
         // forwards to this.onX(). Capture the registered callback per event
@@ -568,6 +598,7 @@ describe('ConnectionEventHandler', () => {
             'onReferences',
             'onImplementation',
             'onRenameRequest',
+            'onDocumentFormatting',
         ] as const;
 
         function makeMockConnection(): Connection {
@@ -585,7 +616,7 @@ describe('ConnectionEventHandler', () => {
         it.each(hooks)('connection.%s callback forwards to the matching instance method', hook => {
             const conn = makeMockConnection();
             const ceh = new (require('../src/connection-event-handler').ConnectionEventHandler)(
-                conn, serverManager, configEventEmitter, requester, editQueue
+                conn, serverManager, configEventEmitter, requester, editQueue, documents
             );
 
             const cb = captureLastCall((conn as any)[hook] as jest.Mock);


### PR DESCRIPTION
Enhancements:
- "Format Document" now reformats ghūl source files. The language
  server advertises `documentFormattingProvider` and forwards the
  buffer to the analyser's new `#FORMAT#` command, applying the
  reformatted result as a single whole-document edit.

Needs a compiler new enough to support `#FORMAT#` (degory/ghul#1320);
with an older compiler the request resolves to no edit.
