### PR TITLE
Add range formatting support

### DIFF
--- a/server/src/connection-event-handler.ts
+++ b/server/src/connection-event-handler.ts
@@ -19,6 +19,7 @@ import {
     WorkspaceEdit,
     TextDocumentSyncKind,
     DocumentFormattingParams,
+    DocumentRangeFormattingParams,
     TextEdit,
     TextDocuments,
 } from 'vscode-languageserver';
@@ -121,6 +122,10 @@ export class ConnectionEventHandler {
         connection.onDocumentFormatting(
             (params: DocumentFormattingParams): Promise<TextEdit[]> =>
                 this.onDocumentFormatting(params));
+
+        connection.onDocumentRangeFormatting(
+            (params: DocumentRangeFormattingParams): Promise<TextEdit[]> =>
+                this.onDocumentRangeFormatting(params));
     }
 
     initialize() {
@@ -194,7 +199,8 @@ export class ConnectionEventHandler {
                 },
                 implementationProvider: true,
                 renameProvider: true,
-                documentFormattingProvider: true
+                documentFormattingProvider: true,
+                documentRangeFormattingProvider: true
             }
         }
     }
@@ -278,6 +284,22 @@ export class ConnectionEventHandler {
             params.textDocument.uri,
             document.getText(),
             whole_document
+        );
+    }
+
+    onDocumentRangeFormatting(params: DocumentRangeFormattingParams): Promise<TextEdit[]> {
+        let document = this.documents.get(params.textDocument.uri);
+
+        if (!document) {
+            return Promise.resolve([]);
+        }
+
+        // The analyser snaps the requested range out to whole enclosing
+        // definitions/statements and replies with the exact span it formatted.
+        return this.requester.sendDocumentRangeFormatting(
+            params.textDocument.uri,
+            document.getText(),
+            params.range
         );
     }
 }

--- a/server/src/requester.ts
+++ b/server/src/requester.ts
@@ -233,6 +233,25 @@ export class Requester {
         }
     }
 
+    sendDocumentRangeFormatting(uri: string, source: string, range: Range): Promise<TextEdit[]> {
+        if (this.analysed) {
+            startWatchdogIfNotRunning();
+
+            this.write('#FORMATRANGE#\n');
+            this.write(normalizeFileUri(uri) + '\n');
+            this.write((range.start.line + 1) + '\n');
+            this.write((range.start.character + 1) + '\n');
+            this.write((range.end.line + 1) + '\n');
+            this.write((range.end.character + 1) + '\n');
+            this.write(source);
+            this.write('\f');
+
+            return this.response_handler.expectDocumentRangeFormatting();
+        } else {
+            return null;
+        }
+    }
+
     sendFullCompileRequest() {
         startWatchdogIfNotRunning();
 

--- a/server/src/response-handler.ts
+++ b/server/src/response-handler.ts
@@ -114,6 +114,7 @@ export class ResponseHandler {
     _implementation_promise_queue: PromiseQueue<Location[]>;
     _rename_promise_queue: PromiseQueue<WorkspaceEdit>;
     _formatting_promise_queue: PromiseQueue<TextEdit[]>;
+    _range_formatting_promise_queue: PromiseQueue<TextEdit[]>;
 
     // The full-document range to replace, one per pending format request,
     // paired FIFO with _formatting_promise_queue.
@@ -139,6 +140,7 @@ export class ResponseHandler {
         this._implementation_promise_queue = new PromiseQueue<Location[]>("IMPLEMENTATION");
         this._rename_promise_queue = new PromiseQueue<WorkspaceEdit>("RENAMEREQUEST");
         this._formatting_promise_queue = new PromiseQueue<TextEdit[]>("FORMAT");
+        this._range_formatting_promise_queue = new PromiseQueue<TextEdit[]>("FORMATRANGE");
     }
 
     onConfigAvailable(_workspace: string, config: GhulConfig) {
@@ -156,6 +158,7 @@ export class ResponseHandler {
         this._implementation_promise_queue.resolveAll([]);
         this._rename_promise_queue.resolveAll(null);
         this._formatting_promise_queue.resolveAll([]);
+        this._range_formatting_promise_queue.resolveAll([]);
         this._formatting_ranges = [];
     }
 
@@ -170,6 +173,7 @@ export class ResponseHandler {
         this._implementation_promise_queue.rejectAll(message);
         this._rename_promise_queue.reject(message);
         this._formatting_promise_queue.rejectAll(message);
+        this._range_formatting_promise_queue.rejectAll(message);
         this._formatting_ranges = [];
     }
 
@@ -576,6 +580,42 @@ export class ResponseHandler {
             resolve([{ range, newText }]);
         } catch(e) {
             log("document formatting: caught:" + e);
+            resolve([]);
+        }
+    }
+
+    expectDocumentRangeFormatting(): Promise<TextEdit[]> {
+        return this._range_formatting_promise_queue.enqueue();
+    }
+
+    handleDocumentRangeFormatting(lines: string[]) {
+        let {resolve} = this._range_formatting_promise_queue.dequeueAlways();
+
+        try {
+            // First line is the tab-separated 1-based span the compiler chose
+            // to format (start line, start column, end line, end column); the
+            // rest is the replacement text. A zero start line means nothing
+            // was formatted.
+            let fields = (lines[0] ?? "").split('\t');
+
+            let startLine = parseInt(fields[0]);
+
+            if (!startLine) {
+                resolve([]);
+                return;
+            }
+
+            let edit = {
+                range: {
+                    start: { line: startLine - 1, character: parseInt(fields[1]) - 1 },
+                    end: { line: parseInt(fields[2]) - 1, character: parseInt(fields[3]) - 1 }
+                },
+                newText: lines.slice(1).join('\n')
+            };
+
+            resolve([edit]);
+        } catch(e) {
+            log("document range formatting: caught:" + e);
             resolve([]);
         }
     }

--- a/server/src/response-parser.ts
+++ b/server/src/response-parser.ts
@@ -145,6 +145,12 @@ export class ResponseParser {
             this.response_handler.handleDocumentFormatting(lines);
             break;
 
+        case "FORMATRANGE":
+            clearWatchdog();
+
+            this.response_handler.handleDocumentRangeFormatting(lines);
+            break;
+
         default:
             // not a known command, but compiler presumably still alive
             clearWatchdog();

--- a/server/tests/connection-event-handler.test.ts
+++ b/server/tests/connection-event-handler.test.ts
@@ -86,6 +86,7 @@ describe('ConnectionEventHandler', () => {
                 showWarningMessage: jest.fn(),
             },
             onDocumentFormatting: jest.fn(),
+            onDocumentRangeFormatting: jest.fn(),
         } as any as Connection;
 
         serverManager = {
@@ -286,7 +287,8 @@ describe('ConnectionEventHandler', () => {
                 },
                 implementationProvider: true,
                 renameProvider: true,
-                documentFormattingProvider: true
+                documentFormattingProvider: true,
+                documentRangeFormattingProvider: true
             }
         });
     });
@@ -575,6 +577,36 @@ describe('ConnectionEventHandler', () => {
         expect(result).toEqual([]);
     });
 
+    it('should handle onDocumentRangeFormatting event', async () => {
+        const edit = { range: { start: { line: 3, character: 0 }, end: { line: 5, character: 0 } }, newText: 'formatted' };
+        const sendDocumentRangeFormatting = jest.fn().mockResolvedValue([edit]);
+        (requester as any).sendDocumentRangeFormatting = sendDocumentRangeFormatting;
+        (documents.get as jest.Mock).mockReturnValue({ getText: () => 'source', lineCount: 9 });
+
+        const range = { start: { line: 3, character: 4 }, end: { line: 5, character: 0 } };
+        const result = await connectionEventHandler.onDocumentRangeFormatting({
+            textDocument: { uri: 'test-uri' },
+            range,
+        } as any);
+
+        expect(sendDocumentRangeFormatting).toHaveBeenCalledWith('test-uri', 'source', range);
+        expect(result).toEqual([edit]);
+    });
+
+    it('onDocumentRangeFormatting returns no edits for an untracked document', async () => {
+        const sendDocumentRangeFormatting = jest.fn();
+        (requester as any).sendDocumentRangeFormatting = sendDocumentRangeFormatting;
+        (documents.get as jest.Mock).mockReturnValue(undefined);
+
+        const result = await connectionEventHandler.onDocumentRangeFormatting({
+            textDocument: { uri: 'missing-uri' },
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+        } as any);
+
+        expect(sendDocumentRangeFormatting).not.toHaveBeenCalled();
+        expect(result).toEqual([]);
+    });
+
     describe('connection.onX callbacks registered by constructor', () => {
         // The constructor wires each connection.onX with an inline arrow that
         // forwards to this.onX(). Capture the registered callback per event
@@ -599,6 +631,7 @@ describe('ConnectionEventHandler', () => {
             'onImplementation',
             'onRenameRequest',
             'onDocumentFormatting',
+            'onDocumentRangeFormatting',
         ] as const;
 
         function makeMockConnection(): Connection {


### PR DESCRIPTION
Enhancements:
- "Format Selection" now reformats ghūl source. The language server
  advertises `documentRangeFormattingProvider` and forwards the
  selection to the analyser's new `#FORMATRANGE#` command, applying the
  reformatted span the analyser returns.

Needs a compiler new enough to support `#FORMATRANGE#` (degory/ghul#1323);
with an older compiler the request resolves to no edit.
