### PR TITLE
Recover the analyser cleanly after a recycle

### DIFF
--- a/server/src/extension-state.ts
+++ b/server/src/extension-state.ts
@@ -159,6 +159,10 @@ export function startWatchdogIfNotRunning() {
     ExtensionState.getInstance().watchdog.startWatchdogIfNotRunning();
 }
 
+export function enterWatchdogColdStart() {
+    ExtensionState.getInstance().watchdog.enterColdStart();
+}
+
 export function startWatchdog() {
     ExtensionState.getInstance().watchdog.startWatchdog();
 }

--- a/server/src/response-parser.ts
+++ b/server/src/response-parser.ts
@@ -14,6 +14,14 @@ export class ResponseParser {
         this.response_handler = response_handler;
     }
 
+    // Drop any half-received frame. Called on every (re)launch: a compiler
+    // killed mid-frame leaves a partial section behind, and without this the
+    // replacement compiler's first frame — its LISTEN — is concatenated onto
+    // that fragment, fails to parse, and the project is never analysed.
+    reset() {
+        this.buffer = '';
+    }
+
     handleChunk(chunk: string) {
         chunk = chunk.replace(/\r/g, '');
 

--- a/server/src/server-manager.ts
+++ b/server/src/server-manager.ts
@@ -9,7 +9,7 @@ import {
 import { Connection } from 'vscode-languageserver';
 
 import { log } from './log';
-import { rejectAllPendingPromises, resolveAllPendingPromises } from './extension-state';
+import { enterWatchdogColdStart, rejectAllPendingPromises, resolveAllPendingPromises } from './extension-state';
 
 import { GhulConfig } from './ghul-config';
 
@@ -97,6 +97,10 @@ export class ServerManager {
 			log("killing running compiler PID " + this.child.pid);
 			this.expecting_exit = true;
 
+			// Stop routing the outgoing compiler's stdout into the shared
+			// parser — its dying output must not bleed into the replacement's
+			// frames.
+			this.child.stdout?.removeAllListeners('data');
 			this.child.kill();
 		}
 
@@ -160,6 +164,14 @@ export class ServerManager {
 		this.child.stderr.on('data', (chunk: Buffer) => {
 			process.stderr.write(chunk);
 		});
+
+		// A killed compiler can leave a half-received frame in the shared
+		// parser and a watchdog timer still ticking. Clear both before the
+		// replacement's output starts: a stale frame would corrupt its LISTEN
+		// and leave the project unanalysed, and the calibrated timeout would
+		// kill it part-way through its cold first compile.
+		this.response_parser.reset();
+		enterWatchdogColdStart();
 
 		this.child.stdout.on('data', (chunk: Buffer) => {
 			this.response_parser.handleChunk(chunk.toString());

--- a/server/src/watchdog.ts
+++ b/server/src/watchdog.ts
@@ -1,5 +1,13 @@
 import { log } from './log';
 
+// A freshly launched compiler's first full compile is cold: the JIT and the
+// compiler's symbol and reflection-metadata caches are unwarmed, so it can
+// legitimately take far longer than a calibrated steady-state compile. Until
+// that first compile lands and the edit queue narrows the timeout from a real
+// measurement, the watchdog runs with this wide bound so it cannot mistake a
+// healthy cold compiler for a wedged one.
+export const COLD_START_TIMEOUT_MILLISECONDS = 60000;
+
 // Bounds how long the extension waits for the compiler to answer a request.
 // The timer is (re)started when a request is sent and cleared when any frame
 // comes back; if it fires, the compiler is wedged — it has neither answered
@@ -38,6 +46,15 @@ export class Watchdog {
             clearTimeout(this.watchdog_timer);
             this.watchdog_timer = null;
         }
+    }
+
+    // Called on every (re)launch. Drops any timer still running against the
+    // outgoing compiler and widens the timeout for the incoming one's cold
+    // first compile. The edit queue narrows it again from the first measured
+    // compile.
+    enterColdStart() {
+        this.clearWatchdog();
+        this.timeout_milliseconds = COLD_START_TIMEOUT_MILLISECONDS;
     }
 
     // The compiler has not answered within the timeout. A crash would have

--- a/server/tests/server-manager.test.ts
+++ b/server/tests/server-manager.test.ts
@@ -9,7 +9,7 @@ import { EditQueue } from '../src/edit-queue';
 import { ResponseParser } from '../src/response-parser';
 import { ResponseHandler } from '../src/response-handler';
 import { ExtensionState } from '../src/extension-state';
-import { Watchdog } from '../src/watchdog';
+import { Watchdog, COLD_START_TIMEOUT_MILLISECONDS } from '../src/watchdog';
 import { GhulConfig } from '../src/ghul-config';
 
 // jest.mock calls are hoisted above the imports so writeFileSync and spawn
@@ -202,6 +202,13 @@ describe('ServerManager (state helpers)', () => {
                 resolveAllPendingPromises: jest.fn(),
                 rejectAllPendingPromises: jest.fn(),
             } as unknown as ResponseHandler;
+
+            // launch() resets the parser before wiring the replacement's
+            // stdout; give it a stub so that call doesn't throw.
+            manager.response_parser = {
+                reset: jest.fn(),
+                handleChunk: jest.fn(),
+            } as unknown as ResponseParser;
         });
 
         afterEach(() => {
@@ -316,7 +323,10 @@ describe('ServerManager (state helpers)', () => {
 
         it('child stdout chunks are forwarded to the response parser', () => {
             const handleChunkSpy = jest.fn();
-            manager.response_parser = { handleChunk: handleChunkSpy } as unknown as ResponseParser;
+            manager.response_parser = {
+                reset: jest.fn(),
+                handleChunk: handleChunkSpy,
+            } as unknown as ResponseParser;
 
             const child = makeFakeChild();
             (spawn as jest.Mock).mockImplementationOnce(() => child);
@@ -326,6 +336,51 @@ describe('ServerManager (state helpers)', () => {
             child.stdout.emit('data', Buffer.from('LISTEN\n\f'));
 
             expect(handleChunkSpy).toHaveBeenCalledWith('LISTEN\n\f');
+        });
+
+        it('resets the response parser on launch so a killed compiler\'s '
+            + 'partial frame cannot corrupt the replacement', () => {
+            const resetSpy = jest.fn();
+            manager.response_parser = {
+                reset: resetSpy,
+                handleChunk: jest.fn(),
+            } as unknown as ResponseParser;
+
+            manager.start();
+
+            expect(resetSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('stops routing the outgoing child\'s stdout into the parser before '
+            + 'killing it', () => {
+            const handleChunkSpy = jest.fn();
+            manager.response_parser = {
+                reset: jest.fn(),
+                handleChunk: handleChunkSpy,
+            } as unknown as ResponseParser;
+
+            const oldChild = makeFakeChild(1111);
+            manager.child = oldChild;
+
+            manager.start();
+
+            // The outgoing child's dying output must not reach the parser and
+            // bleed into the replacement's frames.
+            oldChild.stdout.emit('data', Buffer.from('half a fra'));
+
+            expect(handleChunkSpy).not.toHaveBeenCalled();
+        });
+
+        it('enters watchdog cold start on launch so the replacement\'s cold '
+            + 'first compile is not killed', () => {
+            const state = ExtensionState.getInstance();
+            // A calibrated steady-state timeout, as the edit queue would leave it.
+            state.watchdog.setTimeout(3676);
+
+            manager.start();
+
+            expect(state.watchdog.timeout_milliseconds)
+                .toBe(COLD_START_TIMEOUT_MILLISECONDS);
         });
 
         it('refuses to spawn and reports a diagnostic when no compiler is resolved', () => {

--- a/server/tests/watchdog.test.ts
+++ b/server/tests/watchdog.test.ts
@@ -1,4 +1,4 @@
-import { Watchdog } from '../src/watchdog';
+import { Watchdog, COLD_START_TIMEOUT_MILLISECONDS } from '../src/watchdog';
 
 describe('Watchdog', () => {
     let watchdog: Watchdog;
@@ -69,5 +69,25 @@ describe('Watchdog', () => {
     it('clearWatchdog on an unstarted watchdog is a no-op', () => {
         expect(() => watchdog.clearWatchdog()).not.toThrow();
         expect(watchdog.watchdog_timer).toBeUndefined();
+    });
+
+    it('enterColdStart widens the timeout to the cold-start bound', () => {
+        watchdog.setTimeout(3676);
+
+        watchdog.enterColdStart();
+
+        expect(watchdog.timeout_milliseconds).toBe(COLD_START_TIMEOUT_MILLISECONDS);
+    });
+
+    it('enterColdStart drops a timer still running against the outgoing compiler', () => {
+        watchdog.startWatchdog();
+
+        watchdog.enterColdStart();
+
+        expect(watchdog.watchdog_timer).toBeNull();
+
+        // The dropped timer must not fire after the cold start.
+        jest.advanceTimersByTime(2000);
+        expect(onTimeout).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Bugs fixed:

- After a recycle the watchdog could kill the freshly launched compiler part-way through its cold first compile: the timeout was still the warm steady-state value, which a cold compile of the whole project overruns. The watchdog now widens to a cold-start bound on every launch and narrows again from the first measured compile.

- A compiler killed mid-frame left a partial frame in the shared response parser. The replacement's first frame — its LISTEN — was appended to that fragment, failed to parse, and the project was never analysed, so hover and the rest answered against an empty project. The parser is now reset on every launch, and the outgoing compiler's stdout is unhooked before it is killed.