### PR TITLE
Send an explicit heap-check request during an editing lull

### DIFF
--- a/server/src/edit-queue.ts
+++ b/server/src/edit-queue.ts
@@ -2,7 +2,7 @@ import { TextDocumentChangeEvent } from 'vscode-languageserver'
 
 import { log } from './log';
 
-import { getWatchdogTimeout, rejectAllAndThrow, setWatchdogTimeout } from './extension-state';
+import { getWatchdogTimeout, isWatchdogRunning, rejectAllAndThrow, setWatchdogTimeout } from './extension-state';
 
 import { Requester } from './requester'
 
@@ -17,6 +17,7 @@ enum QueueState {
     DOING_PARTIAL_COMPILE,
     WAITING_FOR_MORE_EDITS_AFTER_PARTIAL_COMPILE,
     DOING_FULL_COMPILE,
+    DOING_HEAP_CHECK,
 }
 
 interface Document {
@@ -33,6 +34,10 @@ export class EditQueue {
     edit_timeout: number;
     edit_timer: NodeJS.Timeout;
 
+    // Long-period timer, armed only in the IDLE state — strictly outside the
+    // edit/compile timer's territory, so the two never run at the same time.
+    idle_timer: NodeJS.Timeout;
+
     edit_count: number;
     build_count: number;
 
@@ -48,6 +53,10 @@ export class EditQueue {
 
     static readonly FULL_BUILD_EDIT_TIMEOUT = 1000;
     static readonly PARTIAL_BUILD_EDIT_TIMEOUT = 100;
+
+    // How long the queue must sit IDLE before asking the analyser to sample
+    // the heap — long enough that it is a genuine lull in editing.
+    static readonly HEAP_CHECK_IDLE_TIMEOUT = 60000;
     
     constructor(
         requester: Requester
@@ -68,6 +77,7 @@ export class EditQueue {
 
     reset() {
         this.pending_changes.clear();
+        this.clearIdleTimer();
 
         this.state = QueueState.IDLE;
     }
@@ -95,8 +105,10 @@ export class EditQueue {
         if (this.state == QueueState.START) {
             // do nothing
         } else if (this.state == QueueState.IDLE) {
+            this.clearIdleTimer();
+
             this.state = QueueState.WAITING_FOR_MORE_EDITS;
-            
+
             this.startEditTimer(this.edit_timeout);
         } else if (this.state == QueueState.WAITING_FOR_MORE_EDITS) {
             this.resetEditTimer(this.edit_timeout);
@@ -108,6 +120,8 @@ export class EditQueue {
             this.resetEditTimer(this.edit_timeout);
         } else if (this.state == QueueState.DOING_FULL_COMPILE) {
             // do nothing, wait for full compiler to complete
+        } else if (this.state == QueueState.DOING_HEAP_CHECK) {
+            // do nothing, wait for the heap check to complete
         } else {
             rejectAllAndThrow("queue edit: unexpected queue state (A): " + QueueState[this.state]);
         }
@@ -124,6 +138,23 @@ export class EditQueue {
             }
         } else {
             log("timer expired but not waiting for edits: " + QueueState[this.state] + " (" + this.state + ")");
+        }
+    }
+
+    // The queue has sat IDLE long enough to be a genuine lull, so ask the
+    // analyser to sample the heap — its forced GC then lands off the latency
+    // path of interactive requests. Query requests (hover, completion, …)
+    // bypass this queue, so the queue can be IDLE while a request is still in
+    // flight; if anything is outstanding, the heap check is dropped and the
+    // idle timer re-armed for the next lull rather than risk overlapping it
+    // with another request.
+    onIdleTimeout() {
+        if (this.state == QueueState.IDLE && !isWatchdogRunning()) {
+            this.requester.sendHeapCheckRequest();
+
+            this.state = QueueState.DOING_HEAP_CHECK;
+        } else {
+            this.startIdleTimer();
         }
     }
 
@@ -189,6 +220,23 @@ export class EditQueue {
             this.startEditTimer(this.edit_timeout);
         } else {
             this.state = QueueState.IDLE;
+            this.startIdleTimer();
+        }
+    }
+
+    onHeapCheckDone() {
+        if (this.state != QueueState.DOING_HEAP_CHECK) {
+            log("edit queue: on heap check done: unexpected queue state: " + QueueState[this.state]);
+        }
+
+        if (this.pending_changes.size > 0) {
+            this.state = QueueState.WAITING_FOR_MORE_EDITS;
+            this.startEditTimer(this.edit_timeout);
+        } else {
+            // Back to IDLE, but the idle timer is deliberately not re-armed:
+            // with no edits there are no compiles, so the heap is not growing.
+            // The next full compile re-arms it.
+            this.state = QueueState.IDLE;
         }
     }
 
@@ -211,6 +259,22 @@ export class EditQueue {
 
     startEditTimer(timeout: number) {
         this.edit_timer = setTimeout(() => { this.onEditTimeout() }, timeout);
+    }
+
+    // Self-clearing, so it is safe to call from every IDLE entry point
+    // (onFullCompileDone, and onIdleTimeout when it re-arms) without leaking
+    // a second timer.
+    startIdleTimer() {
+        this.clearIdleTimer();
+
+        this.idle_timer = setTimeout(() => { this.onIdleTimeout() }, EditQueue.HEAP_CHECK_IDLE_TIMEOUT);
+    }
+
+    clearIdleTimer() {
+        if (this.idle_timer) {
+            clearTimeout(this.idle_timer);
+            this.idle_timer = null;
+        }
     }
 
     start(documents: { uri: string, source: string }[]) {

--- a/server/src/extension-state.ts
+++ b/server/src/extension-state.ts
@@ -175,6 +175,10 @@ export function clearWatchdog() {
     ExtensionState.getInstance().watchdog.clearWatchdog();
 }
 
+export function isWatchdogRunning() {
+    return ExtensionState.getInstance().watchdog.isRunning();
+}
+
 export function resolveAllPendingPromises() {
     ExtensionState.getInstance().resolveAllPendingPromises();
 }

--- a/server/src/requester.ts
+++ b/server/src/requester.ts
@@ -257,7 +257,16 @@ export class Requester {
 
         this.write('#COMPILE#\n');
     }
- 
+
+    // Ask the analyser to sample the heap. The EditQueue sends this during a
+    // lull in editing, so the watchdog's forced GC stays off the latency path
+    // of interactive requests.
+    sendHeapCheckRequest() {
+        startWatchdogIfNotRunning();
+
+        this.write('#HEAPCHECK#\n');
+    }
+
     sendRestart() {
         if (this.analysed) {
             startWatchdogIfNotRunning();

--- a/server/src/response-handler.ts
+++ b/server/src/response-handler.ts
@@ -225,6 +225,10 @@ export class ResponseHandler {
         this.edit_queue.onPartialCompileDone(milliseconds);
     }
 
+    handleHeapCheckDone() {
+        this.edit_queue.onHeapCheckDone();
+    }
+
     expectHover(): Promise<Hover> {
         return this._hover_promise_queue.enqueue();
     }

--- a/server/src/response-parser.ts
+++ b/server/src/response-parser.ts
@@ -147,6 +147,12 @@ export class ResponseParser {
             this.response_handler.handleRestart();
             break;
 
+        case "HEAPCHECK":
+            clearWatchdog();
+
+            this.response_handler.handleHeapCheckDone();
+            break;
+
         case "FORMAT":
             clearWatchdog();
 

--- a/server/src/watchdog.ts
+++ b/server/src/watchdog.ts
@@ -57,6 +57,12 @@ export class Watchdog {
         this.timeout_milliseconds = COLD_START_TIMEOUT_MILLISECONDS;
     }
 
+    // True while a request is outstanding: the timer runs from when a request
+    // is sent until a response frame arrives.
+    isRunning(): boolean {
+        return this.watchdog_timer != null;
+    }
+
     // The compiler has not answered within the timeout. A crash would have
     // fired the process 'exit' handler instead, so this is a wedge: nothing
     // recovers it on its own. Hand off to the recovery callback.

--- a/server/tests/edit-queue.test.ts
+++ b/server/tests/edit-queue.test.ts
@@ -11,12 +11,16 @@ import { ExtensionState } from '../src/extension-state';
 class RecordingRequester {
     sendDocumentsCalls: Array<{ uri: string; source: string }[]> = [];
     sendFullCompileRequestCalls = 0;
+    sendHeapCheckRequestCalls = 0;
 
     sendDocuments(documents: { uri: string; source: string }[]) {
         this.sendDocumentsCalls.push(documents);
     }
     sendFullCompileRequest() {
         this.sendFullCompileRequestCalls += 1;
+    }
+    sendHeapCheckRequest() {
+        this.sendHeapCheckRequestCalls += 1;
     }
 }
 
@@ -217,6 +221,73 @@ describe('EditQueue', () => {
             queue.queueEdit3('file:///a.ghul', 1, 't');
             jest.advanceTimersByTime(EditQueue.PARTIAL_BUILD_EDIT_TIMEOUT);
 
+            expect(recorder.sendDocumentsCalls).toHaveLength(1);
+        });
+    });
+
+    describe('heap check', () => {
+        // Drive the queue to IDLE the way a real session does — through a
+        // full compile — so the idle timer is armed.
+        function reachIdleAfterFullCompile() {
+            queue.reset();
+            queue.forceScheduleFullCompile();
+            jest.advanceTimersByTime(EditQueue.FULL_BUILD_EDIT_TIMEOUT);
+            queue.onFullCompileDone(100);
+        }
+
+        it('sends a heap check request after a long idle period following a full compile', () => {
+            reachIdleAfterFullCompile();
+
+            jest.advanceTimersByTime(EditQueue.HEAP_CHECK_IDLE_TIMEOUT);
+
+            expect(recorder.sendHeapCheckRequestCalls).toBe(1);
+        });
+
+        it('does not send a heap check before the idle period elapses', () => {
+            reachIdleAfterFullCompile();
+
+            jest.advanceTimersByTime(EditQueue.HEAP_CHECK_IDLE_TIMEOUT - 1);
+
+            expect(recorder.sendHeapCheckRequestCalls).toBe(0);
+        });
+
+        it('an edit during the idle period cancels the heap check', () => {
+            reachIdleAfterFullCompile();
+
+            queue.queueEdit3('file:///a.ghul', 1, 'text');
+            jest.advanceTimersByTime(EditQueue.HEAP_CHECK_IDLE_TIMEOUT);
+
+            expect(recorder.sendHeapCheckRequestCalls).toBe(0);
+        });
+
+        it('skips the heap check and re-arms while another request is outstanding', () => {
+            reachIdleAfterFullCompile();
+
+            // A query request (hover, completion, …) bypasses the EditQueue;
+            // the watchdog running stands in for "a request is in flight".
+            const watchdog = ExtensionState.getInstance().watchdog;
+            watchdog.setTimeout(10_000_000);
+            watchdog.startWatchdog();
+
+            jest.advanceTimersByTime(EditQueue.HEAP_CHECK_IDLE_TIMEOUT);
+            expect(recorder.sendHeapCheckRequestCalls).toBe(0);
+
+            // Once the request completes, the re-armed timer sends it.
+            watchdog.clearWatchdog();
+            jest.advanceTimersByTime(EditQueue.HEAP_CHECK_IDLE_TIMEOUT);
+            expect(recorder.sendHeapCheckRequestCalls).toBe(1);
+        });
+
+        it('returns to IDLE after the heap check completes', () => {
+            reachIdleAfterFullCompile();
+            jest.advanceTimersByTime(EditQueue.HEAP_CHECK_IDLE_TIMEOUT);
+            expect(recorder.sendHeapCheckRequestCalls).toBe(1);
+
+            queue.onHeapCheckDone();
+
+            // Back in IDLE: a fresh edit schedules an edit timer and sends.
+            queue.queueEdit3('file:///a.ghul', 1, 'text');
+            jest.advanceTimersByTime(EditQueue.PARTIAL_BUILD_EDIT_TIMEOUT);
             expect(recorder.sendDocumentsCalls).toHaveLength(1);
         });
     });


### PR DESCRIPTION
Pairs with the compiler-side `#HEAPCHECK#` command (ghul#1335).

The analyser's heap watchdog samples the managed heap with a forced GC. Coupled to compiles, that GC lands on the latency path of interactive requests. The `EditQueue` now sends an explicit `#HEAPCHECK#` request once editing has been idle for 60s — a genuine lull — so the forced GC happens then instead.

- A new `DOING_HEAP_CHECK` queue state serialises the request like a compile.
- The idle timer is armed only in the `IDLE` state, strictly outside the edit/compile timer's territory, so the two never run at once.
- Query requests (hover, completion, …) bypass the `EditQueue`, so the heap check is dropped — and the idle timer re-armed — if any request is still outstanding when the lull elapses.

5 new `EditQueue` tests; server suite 252 green.