### PR TITLE
Fix edit-queue state-machine desync after a compiler recycle

### DIFF
--- a/server/src/edit-queue.ts
+++ b/server/src/edit-queue.ts
@@ -6,7 +6,6 @@ import { getWatchdogTimeout, isWatchdogRunning, rejectAllAndThrow, setWatchdogTi
 
 import { Requester } from './requester'
 
-import { clearTimeout } from 'timers';
 import { normalizeFileUri } from './normalize-file-uri';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
@@ -77,6 +76,7 @@ export class EditQueue {
 
     reset() {
         this.pending_changes.clear();
+        this.clearEditTimer();
         this.clearIdleTimer();
 
         this.state = QueueState.IDLE;
@@ -111,13 +111,13 @@ export class EditQueue {
 
             this.startEditTimer(this.edit_timeout);
         } else if (this.state == QueueState.WAITING_FOR_MORE_EDITS) {
-            this.resetEditTimer(this.edit_timeout);
+            this.startEditTimer(this.edit_timeout);
         } else if (this.state == QueueState.DOING_PARTIAL_COMPILE) {
             // do nothing, wait for partial compiler to complete
         } else if (this.state == QueueState.WAITING_FOR_MORE_EDITS_AFTER_PARTIAL_COMPILE) {
             this.state = QueueState.WAITING_FOR_MORE_EDITS;
-            
-            this.resetEditTimer(this.edit_timeout);
+
+            this.startEditTimer(this.edit_timeout);
         } else if (this.state == QueueState.DOING_FULL_COMPILE) {
             // do nothing, wait for full compiler to complete
         } else if (this.state == QueueState.DOING_HEAP_CHECK) {
@@ -128,6 +128,10 @@ export class EditQueue {
     }
 
     onEditTimeout() {
+        // The timer has fired; its handle is spent. Drop the reference so a
+        // later clearEditTimer cannot act on a stale handle.
+        this.edit_timer = null;
+
         if (this.state == QueueState.WAITING_FOR_MORE_EDITS) {
             this.sendQueued("edit timeout when waiting for more edits");
         } else if(this.state == QueueState.WAITING_FOR_MORE_EDITS_AFTER_PARTIAL_COMPILE) {
@@ -165,6 +169,14 @@ export class EditQueue {
     }
 
     onPartialCompileDone(milliseconds: number) {
+        if (this.state != QueueState.DOING_PARTIAL_COMPILE) {
+            // A stray PARTIAL DONE — e.g. left over from a compiler recycle.
+            // Drop it rather than driving a transition (and arming an edit
+            // timer) from a state that never requested a partial compile.
+            log("edit queue: on partial compile done: unexpected queue state (C): " + QueueState[this.state] + " (" + this.state + ")");
+            return;
+        }
+
         if (milliseconds) {
             this.edit_timeout = milliseconds * 1.5;
 
@@ -181,20 +193,23 @@ export class EditQueue {
             this.edit_count++;
         }
 
-        if (this.state != QueueState.DOING_PARTIAL_COMPILE) {
-            log("edit queue: on partial compile done: unexpected queue state (C): " + QueueState[this.state] + " (" + this.state + ")");
-        } 
-
         if (this.pending_changes.size > 0) {
             this.state = QueueState.WAITING_FOR_MORE_EDITS;
-            this.startEditTimer(this.edit_timeout);    
+            this.startEditTimer(this.edit_timeout);
         } else {
             this.state = QueueState.WAITING_FOR_MORE_EDITS_AFTER_PARTIAL_COMPILE;
-            this.startEditTimer(this.full_build_timeout);    
+            this.startEditTimer(this.full_build_timeout);
         }
     }
 
     onFullCompileDone(milliseconds: number) {
+        if (this.state != QueueState.DOING_FULL_COMPILE) {
+            // A stray FULL DONE — drop it rather than transitioning from a
+            // state that never requested a full compile.
+            log("edit queue: on full compile done: unexpected queue state: " + QueueState[this.state]);
+            return;
+        }
+
         if (milliseconds) {
             this.full_build_timeout = milliseconds * 1.5;
 
@@ -211,10 +226,6 @@ export class EditQueue {
             this.build_count++;
         }
 
-        if (this.state != QueueState.DOING_FULL_COMPILE) {
-            log("edit queue: on full compile done: unexpected queue state: " + QueueState[this.state]);
-        }
-
         if (this.pending_changes.size > 0) {
             this.state = QueueState.WAITING_FOR_MORE_EDITS;
             this.startEditTimer(this.edit_timeout);
@@ -226,7 +237,10 @@ export class EditQueue {
 
     onHeapCheckDone() {
         if (this.state != QueueState.DOING_HEAP_CHECK) {
+            // A stray heap-check completion — drop it rather than transitioning
+            // from a state that never requested a heap check.
             log("edit queue: on heap check done: unexpected queue state: " + QueueState[this.state]);
+            return;
         }
 
         if (this.pending_changes.size > 0) {
@@ -252,13 +266,23 @@ export class EditQueue {
         this.state = QueueState.DOING_FULL_COMPILE;
     }
 
-    resetEditTimer(timeout: number) {
-        clearTimeout(this.edit_timer);
-        this.startEditTimer(timeout);
+    // Self-clearing, so callers never leak a second edit timer: the queue has
+    // exactly one edit/compile timer and it belongs to whichever WAITING state
+    // armed it. A stale timer that outlived its state would fire onEditTimeout
+    // in an unrelated state — the desync the queue's "unexpected state" logs
+    // were reporting.
+    startEditTimer(timeout: number) {
+        this.clearEditTimer();
+
+        this.edit_timer = setTimeout(() => { this.onEditTimeout() }, timeout);
     }
 
-    startEditTimer(timeout: number) {
-        this.edit_timer = setTimeout(() => { this.onEditTimeout() }, timeout);
+    clearEditTimer() {
+        // Unconditional: clearTimeout is a safe no-op on an absent or already-
+        // fired handle, and a truthiness guard would skip a live timer whose
+        // handle is the falsy 0.
+        clearTimeout(this.edit_timer);
+        this.edit_timer = null;
     }
 
     // Self-clearing, so it is safe to call from every IDLE entry point
@@ -278,17 +302,30 @@ export class EditQueue {
     }
 
     start(documents: { uri: string, source: string }[]) {
-        this.state = QueueState.DOING_PARTIAL_COMPILE;        
+        this.clearEditTimer();
+        this.clearIdleTimer();
+
+        this.state = QueueState.DOING_PARTIAL_COMPILE;
         this.sendMultiEdits(documents);
     }
 
+    // Flush queued edits ahead of a query (completion / signature help) so the
+    // analyser sees the current text before answering. Only meaningful while
+    // WAITING with edits not yet sent: if a compile or heap check is already in
+    // flight the pending edits ride out on its completion, and barging a second
+    // #EDIT# in would leave the queue tracking two in-flight requests as one.
     sendQueued(_why: string = "send queued") {
-        if (this.state == QueueState.WAITING_FOR_MORE_EDITS || this.state == QueueState.WAITING_FOR_MORE_EDITS_AFTER_PARTIAL_COMPILE) {
-            clearTimeout(this.edit_timer);
+        if (
+            this.state != QueueState.WAITING_FOR_MORE_EDITS &&
+            this.state != QueueState.WAITING_FOR_MORE_EDITS_AFTER_PARTIAL_COMPILE
+        ) {
+            return;
         }
 
+        this.clearEditTimer();
+
         this.send_start_time = Date.now();
-        
+
         let documents = <{ uri: string, source: string}[]>[];
 
         for (let change of this.pending_changes.values()) {            

--- a/server/tests/edit-queue.test.ts
+++ b/server/tests/edit-queue.test.ts
@@ -291,4 +291,93 @@ describe('EditQueue', () => {
             expect(recorder.sendDocumentsCalls).toHaveLength(1);
         });
     });
+
+    // Regression cover for the edit-queue desync: an edit timer that outlived
+    // the state that armed it would fire onEditTimeout in an unrelated state,
+    // and the "unexpected queue state" branches would fall through and arm yet
+    // another timer — a self-sustaining cascade of spurious compiles.
+    describe('timer discipline', () => {
+        it('reset() cancels the pending edit timer (compiler recycle)', () => {
+            // An edit arms the edit timer...
+            queue.reset();
+            queue.queueEdit3('file:///a.ghul', 1, 'text');
+
+            // ...then the compiler recycles: reset() returns the queue to IDLE.
+            queue.reset();
+
+            // A fresh analysis runs and reaches WAITING_..._AFTER_PARTIAL_COMPILE,
+            // which arms its own (much longer) full-build timer.
+            queue.start([{ uri: 'file:///a.ghul', source: 'text' }]);
+            queue.onPartialCompileDone(0);
+
+            // Had reset() left the first timer alive it would fire here and
+            // escalate to a full compile ~900ms early.
+            jest.advanceTimersByTime(EditQueue.PARTIAL_BUILD_EDIT_TIMEOUT);
+
+            expect(recorder.sendFullCompileRequestCalls).toBe(0);
+        });
+
+        it('start() cancels the pending edit timer', () => {
+            queue.reset();
+            queue.queueEdit3('file:///a.ghul', 1, 'text');
+
+            // start() drives straight into DOING_PARTIAL_COMPILE without going
+            // through reset() first — it must still cancel the edit timer.
+            queue.start([{ uri: 'file:///a.ghul', source: 'text' }]);
+            queue.onPartialCompileDone(0);
+
+            jest.advanceTimersByTime(EditQueue.PARTIAL_BUILD_EDIT_TIMEOUT);
+
+            expect(recorder.sendFullCompileRequestCalls).toBe(0);
+        });
+
+        it('drops a stray PARTIAL DONE without arming a timer', () => {
+            queue.reset();
+            queue.start([{ uri: 'file:///a.ghul', source: 't' }]);
+            queue.onPartialCompileDone(0);
+            jest.advanceTimersByTime(EditQueue.FULL_BUILD_EDIT_TIMEOUT);
+            expect(recorder.sendFullCompileRequestCalls).toBe(1);
+
+            // A stray PARTIAL DONE arrives while the #COMPILE# is still in
+            // flight — it must not arm an edit timer that escalates again.
+            queue.onPartialCompileDone(0);
+            jest.advanceTimersByTime(EditQueue.FULL_BUILD_EDIT_TIMEOUT);
+
+            expect(recorder.sendFullCompileRequestCalls).toBe(1);
+        });
+
+        it('drops a stray FULL DONE without leaving its waiting state', () => {
+            queue.reset();
+            queue.start([{ uri: 'file:///a.ghul', source: 't' }]);
+            queue.onPartialCompileDone(0);
+
+            // No #COMPILE# has been sent, so this FULL DONE is stray.
+            queue.onFullCompileDone(0);
+
+            // The queue must still be waiting to escalate to a full compile.
+            jest.advanceTimersByTime(EditQueue.FULL_BUILD_EDIT_TIMEOUT);
+
+            expect(recorder.sendFullCompileRequestCalls).toBe(1);
+        });
+
+        it('sendQueued does nothing while a compile is already in flight', () => {
+            queue.reset();
+            queue.start([{ uri: 'file:///a.ghul', source: 't' }]);
+            const sendsAfterStart = recorder.sendDocumentsCalls.length;
+
+            // An edit lands during DOING_PARTIAL_COMPILE, then a completion
+            // trigger flushes the queue. The flush must not barge a second
+            // #EDIT# in alongside the one already in flight.
+            queue.queueEdit3('file:///b.ghul', 1, 'b');
+            queue.sendQueued('completion trigger');
+
+            expect(recorder.sendDocumentsCalls).toHaveLength(sendsAfterStart);
+            expect(queue.pending_changes.size).toBe(1);
+
+            // The queued edit rides out on the in-flight compile completing.
+            queue.onPartialCompileDone(0);
+            jest.advanceTimersByTime(EditQueue.PARTIAL_BUILD_EDIT_TIMEOUT);
+            expect(recorder.sendDocumentsCalls).toHaveLength(sendsAfterStart + 1);
+        });
+    });
 });


### PR DESCRIPTION
Bugs fixed:

- The analyser's edit/compile timer had no disciplined ownership. `reset()` — run on every compiler recycle, crash and watchdog kill — cleared the pending changes and queue state but left the edit timer running. The orphaned timer later fired `onEditTimeout` in an unrelated state; in a WAITING state it sent a spurious `#EDIT#`/`#COMPILE#`, whose `PARTIAL DONE`/`FULL DONE` then arrived in a state the queue did not expect. The "unexpected queue state" branches only logged and fell through into the normal transition, arming yet another timer — a self-sustaining cascade of redundant compiles and "unexpected queue state" / "timer expired but not waiting for edits" log spam.
- `sendQueued` (driven by completion / signature-help triggers) forced the queue into `DOING_PARTIAL_COMPILE` from any state, barging a second `#EDIT#` in alongside a compile already in flight — two requests the queue could only track as one.

Technical:

- `reset()` and `start()` now cancel the edit timer; `startEditTimer` is self-clearing, so the queue holds exactly one edit timer at a time.
- `sendQueued` only flushes from a WAITING state; when a compile or heap check is already in flight the pending edits ride out on its completion.
- the unexpected-state branches in `onPartialCompileDone`, `onFullCompileDone` and `onHeapCheckDone` now drop the stray frame instead of falling through into a transition.
- dropped the `clearTimeout` import from `timers` in favour of the global — the global is canonical and, unlike the module import, is the one jest's fake timers replace, so timer cancellation is now exercised by the suite.
- added regression tests covering recycle (`reset()`/`start()` cancelling a pending timer), stray `PARTIAL DONE`/`FULL DONE` frames, and `sendQueued` while a compile is in flight.