### PR TITLE
Highlight `mut`, `out` and `optional` as keywords

### DIFF
--- a/syntaxes/ghul.tmLanguage.json
+++ b/syntaxes/ghul.tmLanguage.json
@@ -105,7 +105,7 @@
 				},
 				{
 					"name": "storage.modifier.ghul",
-					"match": "(\\b(?<!\\`)(static|public|protected|private|field|let|rec|@)\\b)|(\\b_(?=[A-Za-z]))"
+					"match": "(\\b(?<!\\`)(static|public|protected|private|field|let|mut|rec|out|@)\\b)|(\\b_(?=[A-Za-z]))"
 				},
 				{
 					"name": "keyword.operator.ghul",
@@ -113,7 +113,7 @@
 				},
 				{
 					"name": "keyword.other.ghul",
-					"match": "\\b(?<!\\`)(new|cast|isa|typeof|namespace|class|struct|union|trait|enum|use|innate|is|si)\\b"
+					"match": "\\b(?<!\\`)(new|cast|isa|typeof|namespace|class|struct|union|trait|enum|use|innate|is|si|optional)\\b"
 				},
 				{
 					"name": "entity.name.type.ghul",


### PR DESCRIPTION
Enhancements:
- The TextMate grammar now scopes `mut` and `out` as storage modifiers and `optional` as a keyword (alongside `class`/`struct`). `out` and `optional` are contextual keywords, so they highlight in all positions, including identifier uses.