### PR TITLE
Reload closed source files when they change on disk

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -34,7 +34,7 @@ export function activate(context: ExtensionContext) {
 				workspace.createFileSystemWatcher('**/Directory.Build.props'),
 				workspace.createFileSystemWatcher('**/Directory.Packages.props'),
 				workspace.createFileSystemWatcher('**/dotnet-tools.json'),
-				workspace.createFileSystemWatcher('**/*.ghul', false, true, false),
+				workspace.createFileSystemWatcher('**/*.ghul'),
 			]
 		}
 	}

--- a/server/src/connection-event-handler.ts
+++ b/server/src/connection-event-handler.ts
@@ -161,10 +161,11 @@ export class ConnectionEventHandler {
         // FIXME is there a better way to do this?
         const workspace_root_munged = this.workspace_root.replace(/\\/g, '/');
         
-        this.document_change_tracker = 
+        this.document_change_tracker =
             new DocumentChangeTracker(
                 this.edit_queue,
-                this.config.source.map(glob => `${workspace_root_munged}/${glob}`)
+                this.config.source.map(glob => `${workspace_root_munged}/${glob}`),
+                this.documents
             );
 
         this.config_event_emitter.configAvailable(this.workspace_root, this.config);

--- a/server/src/document-change-tracker.ts
+++ b/server/src/document-change-tracker.ts
@@ -1,4 +1,5 @@
-import { DidChangeWatchedFilesParams, FileChangeType } from "vscode-languageserver";
+import { DidChangeWatchedFilesParams, FileChangeType, TextDocuments } from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
 import { debounce } from "throttle-debounce";
 
@@ -15,13 +16,16 @@ const debounced_reinitialize = debounce(5000, () => { reinitialize(); } );
 export class DocumentChangeTracker {
     edit_queue: EditQueue;
     globs: string[];
+    documents: TextDocuments<TextDocument>;
 
     constructor(
         edit_queue: EditQueue,
-        globs: string[]
+        globs: string[],
+        documents: TextDocuments<TextDocument>
     ) {
         this.edit_queue = edit_queue;
         this.globs = globs;
+        this.documents = documents;
     }
 
     onDidChangeWatchedFiles(params: DidChangeWatchedFilesParams) {
@@ -60,14 +64,33 @@ export class DocumentChangeTracker {
                 log("source file deleted: '", uri, "', clearing in memory");
 
                 this.edit_queue.queueEdit3(uri, null, "");
-            } else if(c.type == FileChangeType.Created) {
-                log("source file created: '", uri, "', initializing from from file contents");
+            } else if(c.type == FileChangeType.Created || c.type == FileChangeType.Changed) {
+                // A file open in an editor is tracked through textDocument
+                // sync; its buffer — not the file on disk — is the source of
+                // truth. Re-reading the saved file here could clobber unsaved
+                // edits, so leave open files to the sync path and only reload
+                // closed files (e.g. those rewritten by a git pull).
+                if (this.isOpenInEditor(uri)) {
+                    continue;
+                }
+
+                log("source file changed on disk: '", uri, "', reloading from file contents");
 
                 let file_contents = readFileSync(fn, "utf8");
 
                 this.edit_queue.queueEdit3(uri, null, file_contents);
             }
         }
+    }
+
+    isOpenInEditor(uri: string) {
+        for (let document of this.documents.all()) {
+            if (normalizeFileUri(document.uri) == uri) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     tryGetValidSourceFile(uri: string) {

--- a/server/tests/document-change-tracker.test.ts
+++ b/server/tests/document-change-tracker.test.ts
@@ -1,4 +1,5 @@
-import { DidChangeWatchedFilesParams, DidCloseTextDocumentParams, FileChangeType } from 'vscode-languageserver';
+import { DidChangeWatchedFilesParams, DidCloseTextDocumentParams, FileChangeType, TextDocuments } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { DocumentChangeTracker } from '../src/document-change-tracker';
 import { EditQueue } from '../src/edit-queue';
@@ -38,6 +39,8 @@ describe('DocumentChangeTracker', () => {
     let editQueue: EditQueue;
     let globs: string[];
     let requester: Requester;
+    let openDocuments: { uri: string }[];
+    let documents: TextDocuments<TextDocument>;
 
     beforeEach(() => {
         editQueue = new EditQueue(requester);
@@ -50,7 +53,14 @@ describe('DocumentChangeTracker', () => {
                 })
         } as unknown as EditQueue;
 
-        documentChangeTracker = new DocumentChangeTracker(editQueue, globs);
+        // Per-test list of editor buffers the tracker should treat as open.
+        openDocuments = [];
+
+        documents = {
+            all: () => openDocuments
+        } as unknown as TextDocuments<TextDocument>;
+
+        documentChangeTracker = new DocumentChangeTracker(editQueue, globs, documents);
     });
 
     it('should queue edit with empty file text for deleted files', () => {
@@ -101,6 +111,50 @@ describe('DocumentChangeTracker', () => {
         documentChangeTracker.onDidChangeWatchedFiles(params);
 
         expect(editQueue.queueEdit3).toHaveBeenCalledWith(uri, null, "contents of file");
+    });
+
+    it('reloads a closed file from disk when it changes on disk (e.g. a git pull)', () => {
+        const uri = 'file:///path/to/document.ghul';
+
+        const fs = require('fs');
+        fs.readFileSync = jest.fn(() => "new contents from disk");
+
+        const params = createDidChangeWatchedFilesParams(uri, FileChangeType.Changed);
+
+        documentChangeTracker.onDidChangeWatchedFiles(params);
+
+        expect(editQueue.queueEdit3).toHaveBeenCalledWith(uri, null, "new contents from disk");
+    });
+
+    it('does not reload an open file when it changes on disk — the editor buffer is the source of truth', () => {
+        const uri = 'file:///path/to/document.ghul';
+
+        // The file is open in an editor, so textDocument sync owns it:
+        openDocuments.push({ uri });
+
+        const fs = require('fs');
+        fs.readFileSync = jest.fn(() => "saved contents from disk");
+
+        const params = createDidChangeWatchedFilesParams(uri, FileChangeType.Changed);
+
+        documentChangeTracker.onDidChangeWatchedFiles(params);
+
+        expect(editQueue.queueEdit3).not.toHaveBeenCalled();
+    });
+
+    it('does not reload an open file on a Created event either', () => {
+        const uri = 'file:///path/to/document.ghul';
+
+        openDocuments.push({ uri });
+
+        const fs = require('fs');
+        fs.readFileSync = jest.fn(() => "contents from disk");
+
+        const params = createDidChangeWatchedFilesParams(uri, FileChangeType.Created);
+
+        documentChangeTracker.onDidChangeWatchedFiles(params);
+
+        expect(editQueue.queueEdit3).not.toHaveBeenCalled();
     });
 
     it('returns early when params has no changes', () => {


### PR DESCRIPTION
Bugs fixed:
- A `.ghul` file rewritten on disk while not open in an editor (for example by a git pull or branch switch) was never re-read, so the analyser kept stale content and reported spurious semantic errors against a mix of old and new files. The client no longer suppresses filesystem change events for `.ghul` files, and the server reloads any changed file that is not currently open in an editor — open files stay owned by the textDocument-sync path so their unsaved edits are kept.