### PR TITLE
Modernise CI workflow

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   version:
-    name: Determine the version number
+    name: Create a version number
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -18,43 +18,68 @@ env:
 
 jobs:
   version:
-    name: Create a version number
-    runs-on: ubuntu-24.04
+    name: Determine the version number
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
-      tag: ${{ steps.create_version.outputs.tag }}
-      package: ${{ steps.create_version.outputs.package }}
+      tag: ${{ steps.package_version.outputs.tag }}
+      package: ${{ steps.package_version.outputs.package }}
 
     permissions:
-      contents: 'write'
+      contents: read
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
 
-    - name: Create version
-      id: create_version
-      uses: degory/create-version@v0.0.2
+    # Calculates the next version from the git history. This action only
+    # reads the repository - it never creates tags or releases. The next
+    # version is a major/minor/patch bump of the most recent vX.Y.Z tag;
+    # a #major or #minor marker in a commit subject picks the bump level,
+    # otherwise each commit bumps the patch number.
+    - name: Calculate the semantic version
+      id: semver
+      uses: paulhatch/semantic-version@v6.0.2
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      env:
-        PRERELEASE: ${{ github.event_name == 'pull_request' }}
+        tag_prefix: 'v'
+        major_pattern: '#major'
+        minor_pattern: '#minor'
+        version_format: '${major}.${minor}.${patch}'
+
+    - name: Determine the package version
+      id: package_version
+      run: |
+        manual="${{ github.event.inputs.version }}"
+        if [ -n "$manual" ]; then
+          # version supplied via the workflow_dispatch input
+          package="${manual#v}"
+        else
+          package="${{ steps.semver.outputs.version }}"
+          # pull request builds get a prerelease version so they can
+          # never collide with a real release
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            package="${package}-beta.${{ github.run_number }}"
+          fi
+        fi
+        echo "tag=v${package}" >> "$GITHUB_OUTPUT"
+        echo "package=${package}" >> "$GITHUB_OUTPUT"
+        echo "Version: v${package}"
 
   unit_tests:
     name: Run unit tests
     needs: [version]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
 
     steps:
     - name: Setup NodeJS
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version: 'lts/*'
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: npm install
@@ -74,16 +99,16 @@ jobs:
 
     timeout-minutes: 5
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     steps:
     - name: Setup NodeJS
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version: 'lts/*'
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: npm install
@@ -98,7 +123,7 @@ jobs:
       run: npx @vscode/vsce package
 
     - name: Upload beta VSCE package artifact to GitHub
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: vsce-package
@@ -110,17 +135,17 @@ jobs:
 
     timeout-minutes: 5
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     # if push and branch is main
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
     - name: Setup NodeJS
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
-        node-version: '22'
+        node-version: 'lts/*'
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: npm install
@@ -135,7 +160,7 @@ jobs:
       run: npx @vscode/vsce package
 
     - name: Upload release VSCE package artifact to GitHub
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: vsce-package
@@ -150,7 +175,7 @@ jobs:
   create_release:
     needs: [version, unit_tests, publish_release_package]
     name: Create release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -159,13 +184,13 @@ jobs:
       contents: 'write'
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Create changelog
       run: git log -1 --format="%s%n%n%b%n%n" >changelog.txt
 
     - name: Download release VSCE package artifact from GitHub
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: vsce-package
 


### PR DESCRIPTION
- replace `degory/create-version` with `paulhatch/semantic-version`; the release tag is now created only by the existing `gh release create` step on push to main; pull requests no longer push prerelease tags. PR builds get a `-beta.<run-number>` suffix to stay clear of real releases
- bump `actions/checkout` v5 → v6
- bump `actions/setup-node` v5 → v6 and track Node LTS via `'lts/*'` (was pinned `'22'`)
- bump `actions/upload-artifact` v4 → v7 and `actions/download-artifact` v4 → v8
- pin `ubuntu-latest` in place of `ubuntu-24.04` across all jobs

This brings the VSCE workflow in line with the other ghul* repos and uses the current major versions of every supported action.